### PR TITLE
🛠️Fix: 미디어 쿼리 적용, 사이즈 프롭 삭제

### DIFF
--- a/components/ButtonSet/ButtonSet.tsx
+++ b/components/ButtonSet/ButtonSet.tsx
@@ -4,7 +4,6 @@ import ArrowIcon from "@/assets/icons/arrow-forward.svg";
 import TYPES from "./ButtonSetStyles";
 
 interface ButtonProps {
-  size: "S" | "M" | "L";
   isDisabled?: boolean;
   buttonType: keyof typeof TYPES;
 }
@@ -16,35 +15,35 @@ interface ButtonSetProps extends ButtonCommonProps {
   children?: React.ReactNode;
 }
 
-const ButtonSet: React.FC<ButtonSetProps> = ({ type, size, isDisabled, children }) => {
+const ButtonSet: React.FC<ButtonSetProps> = ({ type, isDisabled, children }) => {
   return (
     <ButtonSetContainer type={type}>
       {type === "forwardAndBackward" && (
         <>
-          <Button buttonType="forward" size={size} disabled={isDisabled}>
+          <Button buttonType="forward" disabled={isDisabled}>
             <StyledArrowIcon disabled={isDisabled} />
           </Button>
-          <Button buttonType="backward" size={size} disabled={isDisabled}>
+          <Button buttonType="backward" disabled={isDisabled}>
             <StyledArrowIcon disabled={isDisabled} />
           </Button>
         </>
       )}
       {type === "acceptAndReject" && (
         <>
-          <Button buttonType="accept" size={size} disabled={isDisabled}>
+          <Button buttonType="accept" disabled={isDisabled}>
             수락
           </Button>
-          <Button buttonType="reject" size={size} disabled={isDisabled}>
+          <Button buttonType="reject" disabled={isDisabled}>
             거절
           </Button>
         </>
       )}
       {type === "modalSet" && (
         <>
-          <Button buttonType="cancel" size={size} disabled={isDisabled}>
+          <Button buttonType="cancel" disabled={isDisabled}>
             취소
           </Button>
-          <Button buttonType="basic" size={size} disabled={isDisabled}>
+          <Button buttonType="basic" disabled={isDisabled}>
             {children}
           </Button>
         </>
@@ -77,7 +76,7 @@ const Button = styled.button<ButtonProps>`
 
   font-weight: 500;
 
-  ${({ buttonType, size }) => TYPES[buttonType] && size in TYPES[buttonType] && TYPES[buttonType][size]}
+  ${({ buttonType }) => TYPES[buttonType]}
 `;
 
 const StyledArrowIcon = styled(ArrowIcon)`

--- a/components/ButtonSet/ButtonSetStyles.ts
+++ b/components/ButtonSet/ButtonSetStyles.ts
@@ -1,16 +1,31 @@
 import { css } from "styled-components";
-
-interface ButtonTypeStyles {
-  [key: string]: {
-    S: ReturnType<typeof css>;
-    M: ReturnType<typeof css>;
-    L: ReturnType<typeof css>;
-  };
-}
+import { DeviceSize } from "@/styles/DeviceSize";
 
 const TYPES = {
-  accept: {
-    S: css`
+  accept: css`
+    width: 8.4rem;
+
+    padding: 0.7rem 0;
+    border-radius: 4px;
+    border: none;
+
+    background-color: var(--Main);
+
+    color: var(--White);
+
+    @media (max-width: ${DeviceSize.tablet}) {
+      width: 7.2rem;
+
+      padding: 0.6rem 0;
+      border-radius: 4px;
+      border: none;
+
+      background-color: var(--Main);
+
+      color: var(--White);
+    }
+
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 10.9rem;
 
       padding: 0.7rem 0;
@@ -21,32 +36,27 @@ const TYPES = {
 
       color: var(--White);
       font-size: 1.2rem;
-    `,
-    M: css`
+    }
+  `,
+
+  reject: css`
+    width: 8.4rem;
+
+    padding: 0.7rem 0;
+    border-radius: 4px;
+
+    color: var(--Main);
+
+    @media (max-width: ${DeviceSize.tablet}) {
       width: 7.2rem;
 
       padding: 0.6rem 0;
       border-radius: 4px;
-      border: none;
 
-      background-color: var(--Main);
+      color: var(--Main);
+    }
 
-      color: var(--White);
-    `,
-    L: css`
-      width: 8.4rem;
-
-      padding: 0.7rem 0;
-      border-radius: 4px;
-      border: none;
-
-      background-color: var(--Main);
-
-      color: var(--White);
-    `,
-  },
-  reject: {
-    S: css`
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 10.9rem;
 
       padding: 0.7rem 0;
@@ -54,72 +64,53 @@ const TYPES = {
 
       color: var(--Main);
       font-size: 1.2rem;
-    `,
-    M: css`
-      width: 7.2rem;
+    }
+  `,
 
-      padding: 0.6rem 0;
-      border-radius: 4px;
+  forward: css`
+    width: 4rem;
+    height: 4rem;
 
-      color: var(--Main);
-    `,
-    L: css`
-      width: 8.4rem;
+    border-radius: 0 4px 4px 0;
 
-      padding: 0.7rem 0;
-      border-radius: 4px;
+    transform: scaleX(-1);
 
-      color: var(--Main);
-    `,
-  },
-  forward: {
-    S: css`
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 3.6rem;
       height: 3.6rem;
 
       border-radius: 0 4px 4px 0;
 
       transform: scaleX(-1);
-    `,
-    M: css`
-      width: 4rem;
-      height: 4rem;
+    }
+  `,
 
-      border-radius: 0 4px 4px 0;
+  backward: css`
+    width: 4rem;
+    height: 4rem;
 
-      transform: scaleX(-1);
-    `,
-    L: css`
-      width: 4rem;
-      height: 4rem;
+    border-radius: 0 4px 4px 0;
 
-      border-radius: 0 4px 4px 0;
-
-      transform: scaleX(-1);
-    `,
-  },
-  backward: {
-    S: css`
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 3.6rem;
       height: 3.6rem;
 
       border-radius: 0 4px 4px 0;
-    `,
-    M: css`
-      width: 4rem;
-      height: 4rem;
+    }
+  `,
 
-      border-radius: 0 4px 4px 0;
-    `,
-    L: css`
-      width: 4rem;
-      height: 4rem;
+  basic: css`
+    width: 12rem;
 
-      border-radius: 0 4px 4px 0;
-    `,
-  },
-  basic: {
-    S: css`
+    padding: 1.4rem 0;
+    border: none;
+
+    background-color: var(--Main);
+
+    color: var(--White);
+    font-size: 1.6rem;
+
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 13.8rem;
 
       padding: 1.2rem 0;
@@ -128,55 +119,25 @@ const TYPES = {
       background-color: var(--Main);
 
       color: var(--White);
-    `,
-    M: css`
-      width: 12rem;
+    }
+  `,
 
-      padding: 1.4rem 0;
-      border: none;
+  cancel: css`
+    width: 12rem;
 
-      background-color: var(--Main);
+    padding: 1.4rem 0;
 
-      color: var(--White);
-      font-size: 1.6rem;
-    `,
-    L: css`
-      width: 12rem;
+    color: var(--Gray50);
+    font-size: 1.6rem;
 
-      padding: 1.4rem 0;
-      border: none;
-
-      background-color: var(--Main);
-
-      color: var(--White);
-      font-size: 1.6rem;
-    `,
-  },
-  cancel: {
-    S: css`
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 13.8rem;
 
       padding: 1.2rem 0;
 
       color: var(--Gray50);
-    `,
-    M: css`
-      width: 12rem;
-
-      padding: 1.4rem 0;
-
-      color: var(--Gray50);
-      font-size: 1.6rem;
-    `,
-    L: css`
-      width: 12rem;
-
-      padding: 1.4rem 0;
-
-      color: var(--Gray50);
-      font-size: 1.6rem;
-    `,
-  },
+    }
+  `,
 };
 
 export default TYPES;

--- a/components/button/Button.tsx
+++ b/components/button/Button.tsx
@@ -8,7 +8,6 @@ import AddColumn from "@/components/Chip/AddColumn";
 import dashboardData from "./mockData";
 
 interface ButtonContentProps {
-  size: "S" | "M" | "L";
   type: keyof typeof TYPES;
   children: React.ReactNode;
   disabled?: boolean;
@@ -20,7 +19,6 @@ interface ButtonContentProps {
 const ButtonContent: React.FC<ButtonContentProps> = ({ type, children, id, color, title }) => {
   let dashboard;
   if (type === "dashboardList" && id !== undefined) {
-    // dashboard = dashboardData.dashboards.find((d) => d.id === id);
     dashboard = dashboardData.dashboards[0];
   }
 
@@ -57,10 +55,10 @@ const ButtonContent: React.FC<ButtonContentProps> = ({ type, children, id, color
   }
 };
 
-const Button: React.FC<ButtonContentProps> = ({ type, size, children, id, ...props }) => {
+const Button: React.FC<ButtonContentProps> = ({ type, children, id }) => {
   return (
-    <StyledButton type={type} size={size} {...props}>
-      <ButtonContent type={type} size={size} children={children} id={id} />
+    <StyledButton type={type}>
+      <ButtonContent type={type} children={children} id={id} />
     </StyledButton>
   );
 };
@@ -78,7 +76,7 @@ const StyledButton = styled.button<ButtonContentProps>`
 
   font-weight: 500;
 
-  ${({ type, size }) => TYPES[type] && size in TYPES[type] && TYPES[type][size]}
+  ${({ type }) => TYPES[type]}
 `;
 
 const StyledAddBoxIcon = styled(AddBoxIcon)`

--- a/components/button/ButtonStyles.ts
+++ b/components/button/ButtonStyles.ts
@@ -1,16 +1,28 @@
 import { css } from "styled-components";
-
-interface ButtonTypeStyles {
-  [key: string]: {
-    S: ReturnType<typeof css>;
-    M: ReturnType<typeof css>;
-    L: ReturnType<typeof css>;
-  };
-}
+import { DeviceSize } from "@/styles/DeviceSize";
 
 const TYPES = {
-  login: {
-    S: css`
+  login: css`
+    width: 52rem;
+
+    padding: 1.4rem 0;
+    border: none;
+
+    background-color: var(--Main);
+
+    color: var(--White);
+    font-size: 1.8rem;
+    font-weight: 500;
+
+    &:disabled {
+      border: none;
+
+      background-color: var(--Gray40);
+
+      cursor: not-allowed;
+    }
+
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 35.1rem;
 
       padding: 1.4rem 0;
@@ -29,50 +41,18 @@ const TYPES = {
 
         cursor: not-allowed;
       }
-    `,
-    M: css`
-      width: 52rem;
+    }
+  `,
 
-      padding: 1.4rem 0;
-      border: none;
+  delete: css`
+    width: 8.4rem;
 
-      background-color: var(--Main);
+    padding: 0.7rem 0;
 
-      color: var(--White);
-      font-size: 1.8rem;
-      font-weight: 500;
+    border-radius: 4px;
+    color: var(--Main);
 
-      &:disabled {
-        border: none;
-
-        background-color: var(--Gray40);
-
-        cursor: not-allowed;
-      }
-    `,
-    L: css`
-      width: 52rem;
-
-      padding: 1.4rem 0;
-      border: none;
-
-      background-color: var(--Main);
-
-      color: var(--White);
-      font-size: 1.8rem;
-      font-weight: 500;
-
-      &:disabled {
-        border: none;
-
-        background-color: var(--Gray40);
-
-        cursor: not-allowed;
-      }
-    `,
-  },
-  delete: {
-    S: css`
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 5.2rem;
 
       padding: 0.7rem 0;
@@ -80,26 +60,28 @@ const TYPES = {
 
       color: var(--Main);
       font-size: 1.2rem;
-    `,
-    M: css`
-      width: 8.4rem;
+    }
+  `,
+  addNewColumn: css`
+    width: 35.4rem;
 
-      padding: 0.7rem 0;
+    padding: 2.45rem 0;
+    gap: 1.2rem;
 
-      border-radius: 4px;
-      color: var(--Main);
-    `,
-    L: css`
-      width: 8.4rem;
+    font-size: 1.8rem;
+    font-weight: 700;
 
-      padding: 0.7rem 0;
+    @media (max-width: ${DeviceSize.tablet}) {
+      width: 54.4rem;
 
-      border-radius: 4px;
-      color: var(--Main);
-    `,
-  },
-  addNewColumn: {
-    S: css`
+      padding: 2.45rem 0;
+      gap: 1.2rem;
+
+      font-size: 1.8rem;
+      font-weight: 700;
+    }
+
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 28.4rem;
 
       padding: 2rem 0;
@@ -107,48 +89,40 @@ const TYPES = {
 
       font-size: 1.6rem;
       font-weight: 700;
-    `,
-    M: css`
+    }
+  `,
+
+  plus: css`
+    width: 31.4rem;
+
+    padding: 0.9rem 0;
+    border-radius: 6px;
+
+    @media (max-width: ${DeviceSize.tablet}) {
       width: 54.4rem;
 
-      padding: 2.45rem 0;
-      gap: 1.2rem;
+      padding: 0.9rem 0;
+      border-radius: 6px;
+    }
 
-      font-size: 1.8rem;
-      font-weight: 700;
-    `,
-    L: css`
-      width: 35.4rem;
-
-      padding: 2.45rem 0;
-      gap: 1.2rem;
-
-      font-size: 1.8rem;
-      font-weight: 700;
-    `,
-  },
-  plus: {
-    S: css`
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 28.4rem;
 
       padding: 0.6rem 0;
       border-radius: 6px;
-    `,
-    M: css`
-      width: 54.4rem;
+    }
+  `,
 
-      padding: 0.9rem 0;
-      border-radius: 6px;
-    `,
-    L: css`
-      width: 31.4rem;
+  deleteDashboard: css`
+    width: 32rem;
 
-      padding: 0.9rem 0;
-      border-radius: 6px;
-    `,
-  },
-  deleteDashboard: {
-    S: css`
+    padding: 2rem 0;
+
+    background-color: var(--Gray10);
+
+    font-size: 1.8rem;
+
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 28.4rem;
 
       padding: 1.6rem 0;
@@ -156,37 +130,18 @@ const TYPES = {
       background-color: var(--Gray10);
 
       font-size: 1.6rem;
-    `,
-    M: css`
-      width: 32rem;
+    }
+  `,
+  newDashboard: css`
+    width: 33.2rem;
 
-      padding: 2rem 0;
+    padding: 2.4rem 0;
+    gap: 1.2rem;
 
-      background-color: var(--Gray10);
+    font-size: 1.6rem;
+    font-weight: 600;
 
-      font-size: 1.8rem;
-    `,
-    L: css`
-      width: 32rem;
-
-      padding: 2rem 0;
-
-      background-color: var(--Gray10);
-
-      font-size: 1.8rem;
-    `,
-  },
-  newDashboard: {
-    S: css`
-      width: 26rem;
-
-      padding: 1.9rem 0;
-      gap: 1.2rem;
-
-      font-size: 1.6rem;
-      font-weight: 600;
-    `,
-    M: css`
+    @media (max-width: ${DeviceSize.tablet}) {
       width: 24.7rem;
 
       padding: 2.3rem 0;
@@ -194,28 +149,30 @@ const TYPES = {
 
       font-size: 1.6rem;
       font-weight: 600;
-    `,
-    L: css`
-      width: 33.2rem;
+    }
 
-      padding: 2.4rem 0;
+    @media (max-width: ${DeviceSize.mobile}) {
+      width: 26rem;
+
+      padding: 1.9rem 0;
       gap: 1.2rem;
 
       font-size: 1.6rem;
       font-weight: 600;
-    `,
-  },
-  dashboardList: {
-    S: css`
-      width: 26rem;
+    }
+  `,
 
-      padding: 2rem 2rem;
+  dashboardList: css`
+    width: 33.2rem;
 
-      justify-content: space-between;
+    padding: 2.55rem 2rem;
 
-      font-weight: 600;
-    `,
-    M: css`
+    justify-content: space-between;
+
+    font-size: 1.6rem;
+    font-weight: 600;
+
+    @media (max-width: ${DeviceSize.tablet}) {
       width: 24.7rem;
 
       padding: 2.45rem 2rem;
@@ -224,20 +181,29 @@ const TYPES = {
 
       font-size: 1.6rem;
       font-weight: 600;
-    `,
-    L: css`
-      width: 33.2rem;
+    }
 
-      padding: 2.55rem 2rem;
+    @media (max-width: ${DeviceSize.mobile}) {
+      width: 26rem;
+
+      padding: 2rem 2rem;
 
       justify-content: space-between;
 
-      font-size: 1.6rem;
       font-weight: 600;
-    `,
-  },
-  invite: {
-    S: css`
+    }
+  `,
+  invite: css`
+    width: 10.5rem;
+
+    padding: 0.75rem 0;
+    gap: 0.8rem;
+
+    background-color: var(--Main);
+
+    color: var(--White);
+
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 8.6rem;
 
       padding: 0.7rem 0;
@@ -247,56 +213,45 @@ const TYPES = {
 
       color: var(--White);
       font-size: 1.2rem;
-    `,
-    M: css`
-      width: 10.5rem;
+    }
+  `,
 
-      padding: 0.75rem 0;
-      gap: 0.8rem;
+  modalInput: css`
+    width: 8.3rem;
 
-      background-color: var(--Main);
+    padding: 0.9rem 0;
 
-      color: var(--White);
-    `,
-    L: css`
-      width: 10.5rem;
+    color: var(--Main);
+    font-size: 1.2rem;
 
-      padding: 0.75rem 0;
-      gap: 0.8rem;
-
-      background-color: var(--Main);
-
-      color: var(--White);
-    `,
-  },
-  modalInput: {
-    S: css`
-      width: 8.4rem;
-
-      padding: 0.9rem 0;
-
-      color: var(--Main);
-      font-size: 1.2rem;
-    `,
-    M: css`
+    @media (max-width: ${DeviceSize.tablet}) {
       width: 7.8rem;
 
       padding: 0.9rem 0;
 
       color: var(--Main);
       font-size: 1.2rem;
-    `,
-    L: css`
-      width: 8.3rem;
+    }
+
+    @media (max-width: ${DeviceSize.mobile}) {
+      width: 8.4rem;
 
       padding: 0.9rem 0;
 
       color: var(--Main);
       font-size: 1.2rem;
-    `,
-  },
-  modalConfirm: {
-    S: css`
+    }
+  `,
+  modalConfirm: css`
+    width: 12rem;
+
+    padding: 1.4rem 0;
+
+    background-color: var(--Main);
+
+    color: var(--White);
+
+    @media (max-width: ${DeviceSize.mobile}) {
       width: 13.8rem;
 
       padding: 1.2rem 0;
@@ -304,26 +259,8 @@ const TYPES = {
       background-color: var(--Main);
 
       color: var(--White);
-    `,
-    M: css`
-      width: 12rem;
-
-      padding: 1.4rem 0;
-
-      background-color: var(--Main);
-
-      color: var(--White);
-    `,
-    L: css`
-      width: 12rem;
-
-      padding: 1.4rem 0;
-
-      background-color: var(--Main);
-
-      color: var(--White);
-    `,
-  },
+    }
+  `,
 };
 
 export default TYPES;


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- 기존 size prop 삭제하고 미디어 쿼리로 자동 적용되게 변경했습니다. 
- 사용 방식은 아래 참조해주시고 모르겠으면 말씀주세용! (로그인 버튼만 disabled가 제대로 적용 안되는 것 같은데 이 부분 리팩토링할게요!)

`<ButtonSet type="forwardAndBackward" isDisabled={false}></ButtonSet>`
 `<ButtonSet type="forwardAndBackward" isDisabled={true}></ButtonSet>`
 `<ButtonSet type="acceptAndReject" isDisabled={false}></ButtonSet>`
`<ButtonSet type="modalSet" isDisabled={false}>수정</ButtonSet>`
`<Button type="login">로그인</Button>`
`<Button type="login" disabled>로그인</Button>`
`<Button type="delete">삭제</Button>`
`<Button type="addNewColumn">새로운 컬럼 추가하기</Button>`
`<Button type="plus" children={undefined}></Button>`
`<Button type="deleteDashboard">대시보드 삭제하기</Button>`
`<Button type="newDashboard">새로운 대시보드</Button>`
`<Button type="dashboardList" id={0}></Button>`
`<Button type="invite">초대하기</Button>`


***

## 📷 ScreenShot

(아이콘 깨짐은 Chip 리팩토링 반영되면 해결됩니다)

https://github.com/SWCF-8TEAM/taskify/assets/133554119/9092b931-52ca-4faa-8f83-7e0857c9a09c


---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
