### PR TITLE
🍀 refactor: header, sidemenu 컴포넌트 변경사항에 맞게 리팩토링

### DIFF
--- a/components/Nav/DashboardButtons.tsx
+++ b/components/Nav/DashboardButtons.tsx
@@ -1,32 +1,17 @@
-import AddBox from "@/assets/icons/add-box.svg";
 import Settings from "@/assets/icons/settings.svg";
 import { DeviceSize } from "@/styles/DeviceSize";
 import styled from "styled-components";
 
-interface IconButtonProps {
-  icon: React.ReactNode;
-  label: string;
-}
-
-const IconButton = ({ icon, label }: IconButtonProps) => {
+const SettingButton = () => {
   return (
     <StyledButton>
-      <StyledIcon>{icon}</StyledIcon>
-      <ButtonType>{label}</ButtonType>
+      <StyledIcon />
+      <ButtonType>관리</ButtonType>
     </StyledButton>
   );
 };
 
-const DashboardButtons = () => {
-  return (
-    <Wrapper>
-      <IconButton icon={<Settings />} label="관리" />
-      <IconButton icon={<AddBox />} label="초대하기" />
-    </Wrapper>
-  );
-};
-
-export default DashboardButtons;
+export default SettingButton;
 
 const StyledButton = styled.button`
   height: 4rem;
@@ -49,7 +34,7 @@ const StyledButton = styled.button`
   }
 `;
 
-const StyledIcon = styled.div`
+const StyledIcon = styled(Settings)`
   width: 2rem;
   height: 2rem;
 
@@ -65,14 +50,5 @@ const ButtonType = styled.p`
 
   @media (max-width: ${DeviceSize.mobile}) {
     font-size: 1.2em;
-  }
-`;
-
-const Wrapper = styled.div`
-  display: flex;
-  gap: 1.6rem;
-
-  @media (max-width: ${DeviceSize.mobile}) {
-    gap: 0.6rem;
   }
 `;

--- a/components/Nav/DashboardButtons.tsx
+++ b/components/Nav/DashboardButtons.tsx
@@ -26,7 +26,7 @@ const StyledButton = styled.button`
 
   border-radius: 0.8rem;
   border: 1px solid var(--Grayd9);
-  background: var(--White);
+  background: var(--MainBG);
 
   @media (max-width: ${DeviceSize.mobile}) {
     height: 3rem;

--- a/components/Nav/DashboradNav.tsx
+++ b/components/Nav/DashboradNav.tsx
@@ -1,10 +1,11 @@
 import NavContainer from "@/components/Nav/NavContainer";
-import { dashboardData } from "./mockData";
+import { MydashboardData, NotMydashboardData } from "./mockData";
 
 const DashboardNav = () => {
-  const { title, createdByMe } = dashboardData;
+  const { title, createdByMe } = MydashboardData;
+  // const { title, createdByMe } = NotMydashboardData;
 
-  return <NavContainer title={title} createdByMe={createdByMe} />;
+  return <NavContainer title={title} $isDashboard createdByMe={createdByMe} />;
 };
 
 export default DashboardNav;

--- a/components/Nav/MainNav.tsx
+++ b/components/Nav/MainNav.tsx
@@ -27,6 +27,8 @@ const Wrapper = styled.nav`
   align-items: center;
   justify-content: space-between;
 
+  background-color: var(--MainBG);
+
   @media (max-width: ${DeviceSize.tablet}) {
     padding: 1.6rem 4rem 1.6rem 1.6rem;
   }

--- a/components/Nav/MyDashboardNav.tsx
+++ b/components/Nav/MyDashboardNav.tsx
@@ -1,7 +1,7 @@
 import NavContainer from "@/components/Nav/NavContainer";
 
 const MyDashboardNav = () => {
-  return <NavContainer title="내 대시보드" $isMyNav />;
+  return <NavContainer title="내 대시보드" />;
 };
 
 export default MyDashboardNav;

--- a/components/Nav/NavContainer.tsx
+++ b/components/Nav/NavContainer.tsx
@@ -1,29 +1,29 @@
 import Crown from "@/assets/icons/crown.svg";
+import SettingButton from "@/components/Nav/DashboardButtons";
+import Profile from "@/components/Nav/Profile";
+import ProfileImages from "@/components/Nav/ProfileImages";
 import { profileData } from "@/components/Nav/mockData";
 import { DeviceSize } from "@/styles/DeviceSize";
 import styled from "styled-components";
-import DashboardButtons from "@/components/Nav/DashboardButtons";
-import Profile from "@/components/Nav/Profile";
-import ProfileImages from "@/components/Nav/ProfileImages";
 
 interface NavContainerProps {
   title: string;
-  $isMyNav?: boolean;
+  $isDashboard?: boolean;
   createdByMe?: boolean;
 }
 
-const NavContainer = ({ title, $isMyNav = false, createdByMe = false }: NavContainerProps) => {
+const NavContainer = ({ title, $isDashboard = false, createdByMe = false }: NavContainerProps) => {
   const { nickname, profileImageUrl } = profileData;
 
   return (
-    <Wrapper $isMyNav={$isMyNav}>
-      <Title $isMyNav={$isMyNav}>
+    <Wrapper>
+      <Title>
         {title}
         {createdByMe && <Crown alt="왕관" width={20} height={16} />}
       </Title>
-      <Content $isMyNav={$isMyNav}>
-        {$isMyNav || <DashboardButtons />}
-        {$isMyNav || <ProfileImages />}
+      <Content>
+        {createdByMe && <SettingButton />}
+        {$isDashboard && <ProfileImages />}
         <Line />
         <Profile profileImageUrl={profileImageUrl} nickname={nickname} />
       </Content>
@@ -33,7 +33,7 @@ const NavContainer = ({ title, $isMyNav = false, createdByMe = false }: NavConta
 
 export default NavContainer;
 
-const Wrapper = styled.div<{ $isMyNav: boolean }>`
+const Wrapper = styled.div`
   padding: 2.3rem 8rem 2.3rem 34rem;
   border-bottom: 1px solid var(--Grayd9);
 
@@ -43,22 +43,22 @@ const Wrapper = styled.div<{ $isMyNav: boolean }>`
   align-items: center;
   gap: 4rem;
 
+  background-color: var(--MainBG);
+
   @media (max-width: ${DeviceSize.pc}) {
     gap: 3rem;
   }
 
   @media (max-width: ${DeviceSize.tablet}) {
-    padding: 1.5rem 4rem;
-
-    justify-content: ${({ $isMyNav }) => ($isMyNav ? "space-between" : "flex-end")};
+    padding: 1.6rem 4rem 1.6rem 20rem;
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
-    padding: 1.5rem 1.2rem;
+    padding: 1.3rem 1.2rem 1.3rem 9.1rem;
   }
 `;
 
-const Title = styled.div<{ $isMyNav: boolean }>`
+const Title = styled.div`
   color: var(--Black33);
   font-size: 2rem;
   font-weight: 700;
@@ -67,23 +67,23 @@ const Title = styled.div<{ $isMyNav: boolean }>`
   align-items: center;
   gap: 0.8rem;
 
-  @media (max-width: ${DeviceSize.tablet}) {
-    display: ${({ $isMyNav }) => ($isMyNav ? "block" : "none")};
+  @media (max-width: ${DeviceSize.mobile}) {
+    font-size: 1.8rem;
   }
 `;
 
-const Content = styled.div<{ $isMyNav: boolean }>`
+const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: ${({ $isMyNav }) => ($isMyNav ? "3.2rem" : "4rem")};
+  gap: 3.2rem;
 
   @media (max-width: ${DeviceSize.pc}) {
     gap: 2rem;
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
-    gap: "1.6rem";
+    gap: 1.6rem;
   }
 `;
 

--- a/components/Nav/Profile.tsx
+++ b/components/Nav/Profile.tsx
@@ -39,6 +39,21 @@ const ProfileIcon = styled.div<{ image: string }>`
   background-image: url(${(props) => props.image});
   background-size: cover;
   background-repeat: no-repeat;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 3.4rem;
+    height: 3.4rem;
+  }
+`;
+
+const NoProfileImageWrapper = styled.div`
+  font-size: 1.6rem;
+  line-height: 3.8rem;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    font-size: 1.4rem;
+    line-height: 3.4rem;
+  }
 `;
 
 const Name = styled.div`
@@ -49,11 +64,4 @@ const Name = styled.div`
   @media (max-width: ${DeviceSize.mobile}) {
     display: none;
   }
-`;
-
-const NoProfileImageWrapper = styled.div`
-  width: 3.8rem;
-
-  font-size: 1.5rem;
-  line-height: 3.8rem;
 `;

--- a/components/Nav/ProfileImages.tsx
+++ b/components/Nav/ProfileImages.tsx
@@ -20,11 +20,11 @@ const ProfileImages = () => {
             ),
           )}
           {totalCount > 4 && (
-            <Profiles>
+            <NumberWrapper>
               <NumberBackground />
               <NumberPc>+{totalCount - 4}</NumberPc>
               <NumberTabletOrMobile>+{totalCount - 2}</NumberTabletOrMobile>
-            </Profiles>
+            </NumberWrapper>
           )}
         </Contents>
       )}
@@ -44,6 +44,8 @@ const Contents = styled.div`
   justify-content: flex-end;
 
   @media (max-width: ${DeviceSize.tablet}) {
+    width: 9.8rem;
+
     & > :nth-child(n + 3) {
       display: none;
     }
@@ -51,6 +53,10 @@ const Contents = styled.div`
     & > :nth-last-child(-n + 1) {
       display: block;
     }
+  }
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 8.2rem;
   }
 `;
 
@@ -73,9 +79,37 @@ const ProfileImg = styled.div<{ index: number; image: string }>`
   background-repeat: no-repeat;
 
   z-index: ${({ index }) => `${3 - index}`};
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 3.4rem;
+    height: 3.4rem;
+  }
 `;
 
-const Profiles = styled.div`
+const NoProfileImageWrapper = styled.div<{ index: number }>`
+  line-height: 3.8rem;
+
+  padding: 0;
+
+  font-size: 1.5rem;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  right: ${({ index }) => `${(index + 1) * 3}rem`};
+
+  z-index: ${({ index }) => `${3 - index}`};
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    font-size: 1.4rem;
+    line-height: 3.4rem;
+
+    right: ${({ index }) => `${(index + 1) * 2.4}rem`};
+  }
+`;
+
+const NumberWrapper = styled.div`
+  z-index: 5;
+
   > p {
     width: 2rem;
 
@@ -89,7 +123,11 @@ const Profiles = styled.div`
     font-size: 1.6rem;
     font-weight: 500;
 
-    z-index: 5;
+    @media (max-width: ${DeviceSize.mobile}) {
+      right: 0.8rem;
+
+      font-size: 1.4rem;
+    }
   }
 `;
 
@@ -102,7 +140,10 @@ const NumberBackground = styled.div`
   border-radius: 100%;
   border: 2px solid var(--White);
 
-  z-index: 5;
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 3.4rem;
+    height: 3.4rem;
+  }
 `;
 
 const NumberPc = styled.p`
@@ -117,20 +158,4 @@ const NumberTabletOrMobile = styled.p`
   @media (max-width: ${DeviceSize.tablet}) {
     display: block;
   }
-`;
-
-const NoProfileImageWrapper = styled.div<{ index: number }>`
-  width: 3.8rem;
-
-  line-height: 3.8rem;
-
-  padding: 0;
-
-  font-size: 1.5rem;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  right: ${({ index }) => `${(index + 1) * 3}rem`};
-
-  z-index: ${({ index }) => `${3 - index}`};
 `;

--- a/components/Nav/SettingNav.tsx
+++ b/components/Nav/SettingNav.tsx
@@ -1,7 +1,7 @@
 import NavContainer from "@/components/Nav/NavContainer";
 
 const SettingNav = () => {
-  return <NavContainer title="계정관리" $isMyNav={true} />;
+  return <NavContainer title="계정관리" />;
 };
 
 export default SettingNav;

--- a/components/Nav/SettingNav.tsx
+++ b/components/Nav/SettingNav.tsx
@@ -1,7 +1,99 @@
-import NavContainer from "@/components/Nav/NavContainer";
+import LogoButton from "@/components/common/LogoButton";
+import { DeviceSize } from "@/styles/DeviceSize";
+import styled from "styled-components";
+import Profile from "./Profile";
+import { profileData } from "./mockData";
 
 const SettingNav = () => {
-  return <NavContainer title="계정관리" />;
+  const { nickname, profileImageUrl } = profileData;
+
+  return (
+    <Wrapper>
+      <LogoButtonContainer>
+        <LogoButton />
+      </LogoButtonContainer>
+      <ContentContainer>
+        <Title>계정관리</Title>
+        <Content>
+          <Line />
+          <Profile profileImageUrl={profileImageUrl} nickname={nickname} />
+        </Content>
+      </ContentContainer>
+    </Wrapper>
+  );
 };
 
 export default SettingNav;
+
+const Wrapper = styled.div`
+  padding: 2.3rem 8rem 2.3rem 34rem;
+  border-bottom: 1px solid var(--Grayd9);
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4rem;
+
+  background-color: var(--MainBG);
+
+  @media (max-width: ${DeviceSize.pc}) {
+    gap: 3rem;
+  }
+
+  @media (max-width: ${DeviceSize.tablet}) {
+    padding: 1.6rem 4rem 1.6rem 20rem;
+  }
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    padding: 1.3rem 1.2rem;
+  }
+`;
+
+const LogoButtonContainer = styled.div`
+  display: none;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    display: block;
+  }
+`;
+
+const ContentContainer = styled.div`
+  width: 100%;
+
+  display: flex;
+  justify-content: space-between;
+`;
+
+const Title = styled.div`
+  color: var(--Black33);
+  font-size: 2rem;
+  font-weight: 700;
+
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    font-size: 1.8rem;
+  }
+`;
+
+const Content = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 3.2rem;
+
+  @media (max-width: ${DeviceSize.pc}) {
+    gap: 2rem;
+  }
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    gap: 1.6rem;
+  }
+`;
+
+const Line = styled.div`
+  border-left: 1px solid var(--Grayd9);
+  height: 3.8rem;
+`;

--- a/components/Nav/mockData.ts
+++ b/components/Nav/mockData.ts
@@ -73,7 +73,7 @@ const memberData = {
   totalCount: 6,
 };
 
-const dashboardData = {
+const MydashboardData = {
   id: 0,
   title: "비브리지",
   color: "string",
@@ -83,4 +83,14 @@ const dashboardData = {
   userId: 0,
 };
 
-export { profileData, memberData, dashboardData };
+const NotMydashboardData = {
+  id: 0,
+  title: "3분기 계획",
+  color: "string",
+  createdAt: "2023-12-18T16:54:55.261Z",
+  updatedAt: "2023-12-18T16:54:55.261Z",
+  createdByMe: false,
+  userId: 0,
+};
+
+export { profileData, memberData, MydashboardData, NotMydashboardData };

--- a/components/NoProfileImage/ProfileImage.tsx
+++ b/components/NoProfileImage/ProfileImage.tsx
@@ -1,3 +1,4 @@
+import { DeviceSize } from "@/styles/DeviceSize";
 import styled from "styled-components";
 
 const PROFILE_COLOR = ["#A3C4A2", "#FDD446", "#76A5EA", "#0e465d", "#C4B1A2", "#ef823e", "#df8ec1", "#ea3835", "#701cb0", "#137549"];
@@ -6,17 +7,26 @@ const NoProfileImage = () => {
   const ID = 22;
   const nickname = "신혜윤";
 
-  return <Container bgColor={PROFILE_COLOR[ID % 10]}>{nickname[0].toUpperCase()}</Container>;
+  return <Container $bgColor={PROFILE_COLOR[ID % 10]}>{nickname[0].toUpperCase()}</Container>;
 };
 export default NoProfileImage;
 
-const Container = styled.div<{ bgColor: string }>`
-  background-color: ${(props) => props.bgColor};
+const Container = styled.div<{ $bgColor: string }>`
+  width: 3.8rem;
+  height: 3.8rem;
 
-  border-radius: 4.4rem;
+  background-color: ${(props) => props.$bgColor};
+
+  border-radius: 100%;
+  border: 2px solid var(--White);
 
   text-align: center;
-  color: var(--White, #fff);
+  color: var(--White);
   font-family: Montserrat;
   font-weight: 600;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 3.4rem;
+    height: 3.4rem;
+  }
 `;

--- a/components/SideMenu/SettingSideMenu.tsx
+++ b/components/SideMenu/SettingSideMenu.tsx
@@ -1,0 +1,72 @@
+import { DeviceSize } from "@/styles/DeviceSize";
+import styled from "styled-components";
+import LogoButton from "@/components/common/LogoButton";
+import Link from "next/link";
+
+const SettingSideMenu = () => {
+  return (
+    <Wrapper>
+      <LogoButton />
+      <LinkContainer>
+        {/* 페이지만들 때 수정 예정 */}
+        <StyledLink href={"/"}>프로필 설정</StyledLink>
+        <StyledLink href={"/"}>비밀번호 변경</StyledLink>
+      </LinkContainer>
+    </Wrapper>
+  );
+};
+
+export default SettingSideMenu;
+
+const Wrapper = styled.div`
+  width: 30rem;
+  height: 155rem;
+
+  padding: 2rem 1.2rem;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex-shrink: 0;
+
+  border-right: 1px solid var(--Grayd9);
+
+  @media (max-width: ${DeviceSize.tablet}) {
+    width: 16rem;
+    height: 166.6rem;
+  }
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 6.7rem;
+    height: 185.9rem;
+  }
+`;
+
+const LinkContainer = styled.div`
+  width: 100%;
+
+  margin-top: 3rem;
+  margin-left: 1.2rem;
+
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    margin-left: 0;
+
+    text-align: center;
+  }
+`;
+
+const StyledLink = styled(Link)`
+  font-size: 1.6rem;
+
+  &:focus {
+    color: var(--Main);
+  }
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    font-size: 1.4rem;
+  }
+`;

--- a/components/SideMenu/SettingSideMenu.tsx
+++ b/components/SideMenu/SettingSideMenu.tsx
@@ -1,17 +1,17 @@
+import LogoButton from "@/components/common/LogoButton";
 import { DeviceSize } from "@/styles/DeviceSize";
 import styled from "styled-components";
-import LogoButton from "@/components/common/LogoButton";
-import Link from "next/link";
 
 const SettingSideMenu = () => {
   return (
     <Wrapper>
-      <LogoButton />
-      <LinkContainer>
-        {/* 페이지만들 때 수정 예정 */}
-        <StyledLink href={"/"}>프로필 설정</StyledLink>
-        <StyledLink href={"/"}>비밀번호 변경</StyledLink>
-      </LinkContainer>
+      <LogoButtonContainer>
+        <LogoButton />
+      </LogoButtonContainer>
+      <ButtonContainer>
+        <Button>프로필 설정</Button>
+        <Button>비밀번호 변경</Button>
+      </ButtonContainer>
     </Wrapper>
   );
 };
@@ -24,12 +24,17 @@ const Wrapper = styled.div`
 
   padding: 2rem 1.2rem;
 
+  position: absolute;
+  top: 0;
+
   display: flex;
   flex-direction: column;
-  align-items: center;
-  flex-shrink: 0;
 
   border-right: 1px solid var(--Grayd9);
+
+  background-color: var(--MainBG);
+
+  z-index: 3;
 
   @media (max-width: ${DeviceSize.tablet}) {
     width: 16rem;
@@ -37,36 +42,70 @@ const Wrapper = styled.div`
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
-    width: 6.7rem;
-    height: 185.9rem;
+    width: 100%;
+    height: 5rem;
+
+    padding: 0;
+
+    border-bottom: 1px solid var(--Grayd9);
+
+    flex-direction: row;
+
+    top: 6.5rem;
   }
 `;
 
-const LinkContainer = styled.div`
+const LogoButtonContainer = styled.div`
+  @media (max-width: ${DeviceSize.mobile}) {
+    display: none;
+  }
+`;
+
+const ButtonContainer = styled.div`
   width: 100%;
 
-  margin-top: 3rem;
+  margin-top: 6rem;
   margin-left: 1.2rem;
 
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 3rem;
 
+  @media (max-width: ${DeviceSize.tablet}) {
+    margin-top: 4rem;
+  }
+
   @media (max-width: ${DeviceSize.mobile}) {
-    margin-left: 0;
+    margin: 0;
+    padding-left: 6.6rem;
+
+    flex-direction: row;
+    align-items: center;
 
     text-align: center;
   }
 `;
 
-const StyledLink = styled(Link)`
-  font-size: 1.6rem;
+const Button = styled.button`
+  font-size: 1.8rem;
 
   &:focus {
+    font-weight: 700;
     color: var(--Main);
   }
 
+  @media (max-width: ${DeviceSize.tablet}) {
+    font-size: 1.6rem;
+  }
+
   @media (max-width: ${DeviceSize.mobile}) {
-    font-size: 1.4rem;
+    height: 5rem;
+    font-size: 1.5rem;
+
+    &:focus {
+      border-bottom: 2px solid var(--Main);
+      color: var(--Main);
+    }
   }
 `;

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -4,16 +4,21 @@ import LogoButton from "@/components/common/LogoButton";
 import { DeviceSize } from "@/styles/DeviceSize";
 import styled from "styled-components";
 import dashboardData from "./mockData";
+import ArrowButton from "@/assets/icons/arrow-forward.svg";
+import { useState } from "react";
+import Link from "next/link";
 
 interface DashboardProps {
   color: string;
   title: string;
   createdByMe?: boolean;
+  closePopup?: () => void;
 }
 
-const Dashboard = ({ color, title, createdByMe }: DashboardProps) => {
+const Dashboard = ({ color, title, createdByMe, closePopup }: DashboardProps) => {
   return (
-    <Container>
+    // 질 동작하는지 확인하기 위해 임의로 설정한 경로
+    <Container href={"/dashboard"}>
       <Color color={color} />
       <DashboardTitle>{title}</DashboardTitle>
       {createdByMe && <StyledCrown alt="왕관" />}
@@ -23,13 +28,32 @@ const Dashboard = ({ color, title, createdByMe }: DashboardProps) => {
 
 const SideMenu = () => {
   const data = dashboardData.dashboards;
+  const [isPopupVisible, setIsPopupVisible] = useState(false);
+
+  const togglePopup = () => {
+    setIsPopupVisible((prev) => !prev);
+  };
+
+  const closePopup = () => {
+    setIsPopupVisible(false);
+  };
 
   return (
     <Wrapper>
       <LogoButton />
+      <StyledArrowButton onClick={togglePopup} $isPopupVisible={isPopupVisible} />
+      {isPopupVisible && (
+        <Popup>
+          <DashboardList>
+            {data.map((dashboard, key) => {
+              return <Dashboard key={key} color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} closePopup={closePopup} />;
+            })}
+          </DashboardList>
+        </Popup>
+      )}
       <HeaderWrapper>
         <Title>Dash Boards</Title>
-        <AddButton alt="추가 버튼" width={20} height={20} />
+        <StyledAddButton alt="추가 버튼" width={20} height={20} />
       </HeaderWrapper>
       <DashboardList>
         {data.map((dashboard, key) => {
@@ -46,10 +70,11 @@ const Wrapper = styled.div`
   width: 30rem;
   height: 155rem;
 
-  padding: 2rem 2.4rem;
+  padding: 2rem 1.2rem;
 
   display: flex;
   flex-direction: column;
+  align-items: center;
   flex-shrink: 0;
 
   border-right: 1px solid var(--Grayd9);
@@ -66,14 +91,19 @@ const Wrapper = styled.div`
 `;
 
 const HeaderWrapper = styled.div`
-  margin-top: 6rem;
+  margin: 5rem 1.2rem 0;
 
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 16rem;
+
+  @media (max-width: ${DeviceSize.tablet}) {
+    justify-content: center;
+    gap: 2.4rem;
+  }
 
   @media (max-width: ${DeviceSize.mobile}) {
-    margin-top: 3.9rem;
+    margin-top: 2.5rem;
   }
 `;
 
@@ -87,38 +117,55 @@ const Title = styled.div`
   }
 `;
 
+const StyledAddButton = styled(AddButton)`
+  cursor: pointer;
+`;
+
 const DashboardList = styled.div`
-  margin-top: 3rem;
+  width: 27.6rem;
+
+  margin-top: 1.8rem;
 
   display: flex;
   flex-direction: column;
 
   @media (max-width: ${DeviceSize.tablet}) {
-    margin-top: 1.8rem;
+    width: 13.4rem;
   }
 
-  @media (max-width: ${DeviceSize.tablet}) {
-    margin-top: 2.2rem;
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 4rem;
+
+    margin-top: 1.6rem;
   }
 `;
 
-const Container = styled.div`
-  width: 27.6rem;
+const Container = styled(Link)`
   height: 4.5rem;
+
+  padding-left: 1.2rem;
 
   display: flex;
   flex-direction: row;
   align-items: center;
   flex-shrink: 0;
 
+  border-radius: 0.4rem;
+
+  &:hover {
+    background-color: var(--MainBG);
+  }
+
   @media (max-width: ${DeviceSize.tablet}) {
-    width: 13.4rem;
     height: 4.3rem;
+
+    padding-left: 1rem;
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
-    width: 4rem;
     height: 4rem;
+
+    padding-left: 0;
 
     justify-content: center;
   }
@@ -133,6 +180,10 @@ const Color = styled.div<{ color: string }>`
   background-color: ${(props) => props.color};
 
   border-radius: 100%;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    margin-right: 0;
+  }
 `;
 
 const DashboardTitle = styled.div`
@@ -143,8 +194,6 @@ const DashboardTitle = styled.div`
   font-weight: 500;
 
   @media (max-width: ${DeviceSize.tablet}) {
-    margin-right: 0.4rem;
-
     font-size: 1.6rem;
   }
 
@@ -154,15 +203,69 @@ const DashboardTitle = styled.div`
 `;
 
 const StyledCrown = styled(Crown)`
-  width: 1.8rem;
-  height: 1.4rem;
-
-  @media (max-width: ${DeviceSize.tablet}) {
-    width: 1.5rem;
-    height: 1.2rem;
-  }
-
   @media (max-width: ${DeviceSize.mobile}) {
     display: none;
+  }
+`;
+
+const StyledArrowButton = styled(ArrowButton)<{ $isPopupVisible: boolean }>`
+  display: none;
+
+  ${(props) => props.$isPopupVisible && " transform: scaleX(-1)"};
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 2rem;
+    height: 2rem;
+
+    display: block;
+
+    margin-top: 3.9rem;
+
+    cursor: pointer;
+  }
+`;
+
+const Popup = styled.div`
+  display: none;
+
+  position: absolute;
+  top: 15.7rem;
+  left: 8rem;
+
+  border: 1px solid var(--Grayd9);
+  border-radius: 4px;
+
+  background-color: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+  z-index: 999;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    display: block;
+
+    ${DashboardList} {
+      width: 13.4rem;
+
+      margin: 0.8rem 0;
+    }
+
+    ${Container} {
+      justify-content: flex-start;
+    }
+
+    ${Color} {
+      margin-left: 1rem;
+      margin-right: 1.6rem;
+    }
+
+    ${DashboardTitle} {
+      display: block;
+
+      margin-right: 0.6rem;
+    }
+
+    ${StyledCrown} {
+      display: block;
+    }
   }
 `;

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -15,7 +15,7 @@ interface DashboardProps {
   closePopup?: () => void;
 }
 
-const Dashboard = ({ color, title, createdByMe, closePopup }: DashboardProps) => {
+const Dashboard = ({ color, title, createdByMe }: DashboardProps) => {
   return (
     // 질 동작하는지 확인하기 위해 임의로 설정한 경로
     <Container href={"/dashboard"}>
@@ -46,7 +46,7 @@ const SideMenu = () => {
         <Popup>
           <DashboardList>
             {data.map((dashboard, key) => {
-              return <Dashboard key={key} color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} closePopup={closePopup} />;
+              return <Dashboard key={key} color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} />;
             })}
           </DashboardList>
         </Popup>

--- a/components/SideMenu/SideMenu.tsx
+++ b/components/SideMenu/SideMenu.tsx
@@ -72,12 +72,19 @@ const Wrapper = styled.div`
 
   padding: 2rem 1.2rem;
 
+  border-right: 1px solid var(--Grayd9);
+
+  position: absolute;
+  top: 0;
+
   display: flex;
   flex-direction: column;
   align-items: center;
   flex-shrink: 0;
 
-  border-right: 1px solid var(--Grayd9);
+  background-color: var(--MainBG);
+
+  z-index: 3;
 
   @media (max-width: ${DeviceSize.tablet}) {
     width: 16rem;
@@ -153,7 +160,7 @@ const Container = styled(Link)`
   border-radius: 0.4rem;
 
   &:hover {
-    background-color: var(--MainBG);
+    background-color: var(--MainHover);
   }
 
   @media (max-width: ${DeviceSize.tablet}) {
@@ -251,6 +258,10 @@ const Popup = styled.div`
 
     ${Container} {
       justify-content: flex-start;
+
+      &:hover {
+        background-color: var(--MainBG);
+      }
     }
 
     ${Color} {

--- a/components/common/LogoButton.tsx
+++ b/components/common/LogoButton.tsx
@@ -6,14 +6,27 @@ import styled from "styled-components";
 
 const LogoButton = () => {
   return (
-    <Link href="/">
+    <StyledLink href="/">
       <StyledLargeLogo alt="로고 이미지" />
       <StyledSmallLogo alt="로고 이미지" />
-    </Link>
+    </StyledLink>
   );
 };
 
 export default LogoButton;
+
+const StyledLink = styled(Link)`
+  width: 100%;
+  margin-left: 1.2rem;
+
+  display: flex;
+
+  @media (max-width: ${DeviceSize.tablet}) {
+    margin-left: 0;
+
+    justify-content: center;
+  }
+`;
 
 const StyledLargeLogo = styled(LargeLogo)`
   width: 12.1rem;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,3 @@
-import SideMenu from "@/components/SideMenu/SideMenu";
 import { Inter } from "next/font/google";
 import Head from "next/head";
 
@@ -13,7 +12,6 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <SideMenu />
     </>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,4 @@
+import SideMenu from "@/components/SideMenu/SideMenu";
 import { Inter } from "next/font/google";
 import Head from "next/head";
 
@@ -12,6 +13,7 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
+      <SideMenu />
     </>
   );
 }

--- a/styles/ColorStyles.ts
+++ b/styles/ColorStyles.ts
@@ -30,4 +30,5 @@ export const MAIN = css`
   // 추가한 main color
   --Main: #3c6255;
   --MainLight: #faf6f0;
+  --MainBG: #eef2e6;
 `;

--- a/styles/ColorStyles.ts
+++ b/styles/ColorStyles.ts
@@ -31,4 +31,5 @@ export const MAIN = css`
   --Main: #3c6255;
   --MainLight: #faf6f0;
   --MainBG: #eef2e6;
+  --MainHover: #dce6d1;
 `;


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
### header
- 배경화면 색을 수정했습니다
- 계정관리, 내 대시보드용 헤더에서 관리, 초대하기 버튼, 프로필 이미지 리스트를 삭제했습니다
- 내가 만들지 않은 대시보드용 헤더에서 관리, 초대하기 버튼을 삭제했습니다
- 내가 만든 대시보드용 헤더에서 초대하기 버튼을 삭제했습니다
- 버튼들을 삭제하면서 공간에 여유가 생기면서 tablet, mobile 사이즈에서도 제목이 뜨도록 수정했습니다.

### sidemenu
- 배경화면 색을 수정했습니다

기존 sidemenu
-  hover상태일 때 style을 수정했습니다
- onClick 상태를 임의로 설정했습니다
- mobile 사이즈에서 arrow button 클릭할 시 모달이 뜨도록 수정했습니다

계정관리 sidemenu
- 프로필 설정, 비밀번호 변경으로 side menu를 수정했습니다
- mobie size에서 사이드메뉴가 헤더 아래에 위치하도록 수정하고, focus됐을 시 ui도 다르게 구현했습니다
***

## 📷 ScreenShot

### 계정관리 페이지
https://github.com/SWCF-8TEAM/taskify/assets/102296721/d2c05328-317f-41ba-b461-883dac6ed125

### 나머지 페이지

https://github.com/SWCF-8TEAM/taskify/assets/102296721/f588a34e-543c-4aab-86e7-aad815c8563a



---

## ✅ PR CheckList
- [ ] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
header에서 작업하고 sidemenu branch로 올겼어야 하는데... 바로 작업하고 push를 해버렸서요...ㅠㅠㅠㅠㅠ
