### PR TITLE
🍀 refactor: nav 프로필 리팩토링

### DIFF
--- a/components/common/Nav/MemberListDropdown.tsx
+++ b/components/common/Nav/MemberListDropdown.tsx
@@ -35,6 +35,7 @@ const Dropdown = styled.div`
   width: 16rem;
 
   border: 1px solid var(--Grayd9);
+  border-radius: 16px;
 
   position: absolute;
   top: 8%;
@@ -50,16 +51,19 @@ const Item = styled.div`
   align-items: center;
   justify-content: space-between;
 
+  background-color: var(--MainBG);
+
   color: var(--Black33);
   font-size: 1.6rem;
   font-weight: 400;
 
-  &:nth-child(odd) {
-    background-color: #f5f5f5;
+  &:first-child {
+    border-radius: 15px 15px 0 0;
   }
 
   &:last-child {
     border-bottom: 0;
+    border-radius: 0 0 15px 15px;
   }
 `;
 

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -1,3 +1,6 @@
 import { atom } from "jotai";
 
 export const selectedColorAtom = atom("");
+
+// 현재 활성화된 드롭다운의 식별자를 저장하는 아톰
+export const activeDropdownAtom = atom<string | null>(null);


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- 프로필 드롭다운 클릭 시 이미지 반전되도록 수정
- 멤버들 리스트 디자인 수정
- ⭐️Jotai 상태 관리를 사용하여 현재 활성화된 드롭다운의 식별자를 전역 상태로 관리하여 다른 드롭다운이 열릴 때 자동으로 닫히는 기능 구현 
(드롭다운 간의 상호작용을 다룰려면 전역으로 상태 관리를 해야한다고 하더라구요..다른 분들 드롭다운 구현하실 때 제 코드 참고하세욥..)
***

## 📷 ScreenShot
<img width="260" alt="스크린샷 2023-12-26 오후 9 33 19" src="https://github.com/SWCF-8TEAM/taskify/assets/72639353/95f997e6-1ff0-480a-9fe1-be147b06b5e0">
<img width="218" alt="스크린샷 2023-12-26 오후 9 35 18" src="https://github.com/SWCF-8TEAM/taskify/assets/72639353/44ba507f-ad7a-4633-a9dc-c185ca84de7c">
---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
