### PR TITLE
💫 feat: 새로운 대시보드 생성 시 모달 띄우고 취소 버튼 누를 시 닫히도록 구현

### DIFF
--- a/components/Modal/ModalContainer.tsx
+++ b/components/Modal/ModalContainer.tsx
@@ -8,9 +8,10 @@ interface ModalProps {
   title: "새 컬럼 생성" | "컬럼 관리" | "새로운 대시보드";
   label: "이름" | "대시보드 이름";
   buttonType: "생성" | "변경";
+  onClose?: () => void;
 }
 
-const ModalContainer = ({ title, label, buttonType }: ModalProps) => {
+const ModalContainer = ({ title, label, buttonType, onClose }: ModalProps) => {
   return (
     <Wrapper>
       <Title>{title}</Title>
@@ -21,7 +22,9 @@ const ModalContainer = ({ title, label, buttonType }: ModalProps) => {
         </ColorSelectorWrapper>
       )}
       <ButtonWrapper>
-        <ButtonSet type="modalSet">{buttonType}</ButtonSet>
+        <ButtonSet type="modalSet" onClickCancel={onClose}>
+          {buttonType}
+        </ButtonSet>
       </ButtonWrapper>
     </Wrapper>
   );

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -5,6 +5,7 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { styled } from "styled-components";
+import ModalContainer from "@/components/Modal/ModalContainer";
 
 export interface Dashboards {
   id: number;
@@ -21,6 +22,15 @@ const MyDashboardList = () => {
   const [dashboards, setDashboards] = useState<Dashboards[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPageCount, setTotalPageCount] = useState(1);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
 
   useEffect(() => {
     const loadDashboardList = async () => {
@@ -43,7 +53,9 @@ const MyDashboardList = () => {
   return (
     <Wrapper>
       <Container>
-        <Button type="newDashboard">새로운 대시보드</Button>
+        <Button type="newDashboard" onClick={handleOpenModal}>
+          새로운 대시보드
+        </Button>
         {dashboards &&
           dashboards.map((v) => {
             return (
@@ -56,6 +68,11 @@ const MyDashboardList = () => {
       <PageContent>
         {totalPageCount} 페이지 중 {currentPage} <ButtonSet type="forwardAndBackward" />
       </PageContent>
+      {isModalOpen && (
+        <ModalBackdrop>
+          <ModalContainer title="새로운 대시보드" label="대시보드 이름" buttonType="생성" onClose={handleCloseModal} />
+        </ModalBackdrop>
+      )}
     </Wrapper>
   );
 };
@@ -95,4 +112,17 @@ const Wrapper = styled.div`
   flex-direction: column;
   gap: 1.2rem;
   align-items: end;
+`;
+
+const ModalBackdrop = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
 `;

--- a/components/common/Buttons/Button.tsx
+++ b/components/common/Buttons/Button.tsx
@@ -15,6 +15,7 @@ interface ButtonContentProps {
   color?: string;
   title?: string;
   createdByMe?: boolean;
+  onClick?: () => void;
 }
 
 const ButtonContent = ({ type, children, id, title, color, createdByMe }: ButtonContentProps) => {
@@ -51,9 +52,9 @@ const ButtonContent = ({ type, children, id, title, color, createdByMe }: Button
   }
 };
 
-const Button = ({ type, children, disabled, id, title, color, createdByMe }: ButtonContentProps) => {
+const Button = ({ type, children, disabled, id, title, color, createdByMe, onClick }: ButtonContentProps) => {
   return (
-    <StyledButton type={type} disabled={disabled}>
+    <StyledButton type={type} disabled={disabled} onClick={onClick}>
       <ButtonContent type={type} children={children} id={id} title={title} color={color} createdByMe={createdByMe} />
     </StyledButton>
   );

--- a/components/common/Buttons/ButtonSet.tsx
+++ b/components/common/Buttons/ButtonSet.tsx
@@ -8,6 +8,7 @@ interface ButtonProps {
   $buttonType: keyof typeof TYPES;
   onClickForward?: () => void;
   onClickBackward?: () => void;
+  onClickCancel?: () => void;
 }
 
 type ButtonCommonProps = Omit<ButtonProps, "$buttonType">;
@@ -17,7 +18,7 @@ interface ButtonSetProps extends ButtonCommonProps {
   children?: ReactNode;
 }
 
-const ButtonSet = ({ type, isDisabled, children, onClickForward, onClickBackward }: ButtonSetProps) => {
+const ButtonSet = ({ type, isDisabled, children, onClickForward, onClickBackward, onClickCancel }: ButtonSetProps) => {
   return (
     <ButtonSetContainer type={type}>
       {type === "forwardAndBackward" && (
@@ -42,7 +43,7 @@ const ButtonSet = ({ type, isDisabled, children, onClickForward, onClickBackward
       )}
       {type === "modalSet" && (
         <>
-          <Button $buttonType="cancel" disabled={isDisabled}>
+          <Button $buttonType="cancel" disabled={isDisabled} onClick={onClickCancel}>
             취소
           </Button>
           <Button $buttonType="basic" disabled={isDisabled}>


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- '+' 버튼을 클릭하면 대시보드 생성 모달이 나타나도록 하고 취소버튼 누르면 모달 닫게 하기
- 배경을 클릭해도 모달이 안닫히도록 구현!


- 이 과정에서 modalcontainer(혜윤님 담당), Button과 ButtonSet(소희님 담당) 컴포넌트 수정
🥹사유: 버튼 클릭 시 모달 띄우거나 닫아야해서 onclick함수를 프롭으로 넘겨줘야함
***

## 📷 ScreenShot
<img width="984" alt="스크린샷 2023-12-27 오후 7 19 21" src="https://github.com/SWCF-8TEAM/taskify/assets/72639353/ddfb76fb-7bee-4c97-8cac-3e01474a503c">

---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
