### PR TITLE
💫 feat: 초대받은 대시보드 데이터 불러온 후 수락 거절 기능 구현

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -42,7 +42,7 @@ export const ENDPOINTS = {
 
   INVITATIONS: {
     GET: `/invitations`,
-    PUT: (invitationId: string) => `/invitations/${invitationId}`,
+    PUT: (invitationId: number) => `/invitations/${invitationId}`,
   },
 
   MEMBERS: {

--- a/api/invitations/index.ts
+++ b/api/invitations/index.ts
@@ -2,12 +2,7 @@ import instance from "@/api/axios";
 import { ENDPOINTS } from "@/api/config";
 import { GetInvitationProps, GetInvitationsData, Invitation, PutInvitationsProps } from "@/api/invitations/invitations.types";
 
-export const getInvitations = async ({
-  title,
-  size = 5,
-  cursorId,
-  token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzgsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1NzUwMTMsImlzcyI6InNwLXRhc2tpZnkifQ.tt5oPAJ6av4leXf3pT-KW4vNarSQZhjcHA62HfXQjio",
-}: GetInvitationProps): Promise<GetInvitationsData | null> => {
+export const getInvitations = async ({ title, size, cursorId, token }: GetInvitationProps): Promise<GetInvitationsData | null> => {
   try {
     const res = await instance.get(ENDPOINTS.INVITATIONS.GET, {
       params: {

--- a/api/invitations/index.ts
+++ b/api/invitations/index.ts
@@ -19,15 +19,12 @@ export const getInvitations = async ({ title, size, cursorId, token }: GetInvita
   }
 };
 
-export const putInvitations = async ({
-  invitationId = "117",
-  token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MzgsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1NzUwMTMsImlzcyI6InNwLXRhc2tpZnkifQ.tt5oPAJ6av4leXf3pT-KW4vNarSQZhjcHA62HfXQjio",
-}: PutInvitationsProps): Promise<Invitation | null> => {
+export const putInvitations = async ({ invitationId, token, inviteAccepted }: PutInvitationsProps): Promise<Invitation | null> => {
   try {
     const res = await instance.put(
       ENDPOINTS.INVITATIONS.PUT(invitationId),
       {
-        inviteAccepted: true,
+        inviteAccepted,
       },
       {
         headers: {

--- a/api/invitations/invitations.types.ts
+++ b/api/invitations/invitations.types.ts
@@ -12,17 +12,17 @@ export interface Invitation {
     nickname: string;
   };
   inviteAccepted: boolean;
-  createdAt: number;
-  updatedAt: number;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface GetInvitationsData {
-  Invitations: Invitation[];
+  invitations: Invitation[];
   cursorId: number | null;
 }
 
 export interface GetInvitationProps {
-  title: string;
+  title?: string;
   size?: number;
   cursorId?: number;
   token: string;

--- a/api/invitations/invitations.types.ts
+++ b/api/invitations/invitations.types.ts
@@ -29,6 +29,7 @@ export interface GetInvitationProps {
 }
 
 export interface PutInvitationsProps {
-  invitationId: string;
+  invitationId: number;
   token: string;
+  inviteAccepted: boolean;
 }

--- a/components/Table/InvitedDashboard.tsx
+++ b/components/Table/InvitedDashboard.tsx
@@ -4,6 +4,7 @@ import ButtonSet from "@/components/common/Buttons/ButtonSet";
 import NoInvitation from "@/components/Table/NoInvite";
 import { useEffect, useState } from "react";
 import { getInvitations } from "@/api/invitations";
+import { putInvitations } from "@/api/invitations";
 
 interface Invitation {
   id: number;
@@ -22,19 +23,30 @@ const InvitedDashboard = () => {
   const tableTitles = ["이름", "초대자", "수락 여부"];
   const [invitations, setInvitations] = useState<Invitation[]>([]);
 
+  const fetchData = async () => {
+    const data = await getInvitations({
+      size: PAGE_SIZE,
+      token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNjc1NzE2LCJpc3MiOiJzcC10YXNraWZ5In0.J60KP7YBw6JWhFDqk4u3Pm5g9KSCr0UrTt4GAelAvhI",
+    });
+    if (data && data.invitations) {
+      setInvitations(data.invitations);
+    }
+  };
+
   useEffect(() => {
-    const fetchData = async () => {
-      const data = await getInvitations({
-        size: PAGE_SIZE,
-        token:
-          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNjc1NzE2LCJpc3MiOiJzcC10YXNraWZ5In0.J60KP7YBw6JWhFDqk4u3Pm5g9KSCr0UrTt4GAelAvhI",
-      });
-      if (data && data.invitations) {
-        setInvitations(data.invitations);
-      }
-    };
     fetchData();
   }, []);
+
+  const handleInvitationResponse = async (invitationId: number, accept: boolean) => {
+    const updatedInvitation = await putInvitations({
+      invitationId,
+      token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNjc1NzE2LCJpc3MiOiJzcC10YXNraWZ5In0.J60KP7YBw6JWhFDqk4u3Pm5g9KSCr0UrTt4GAelAvhI",
+      inviteAccepted: accept,
+    });
+    if (updatedInvitation) {
+      fetchData();
+    }
+  };
 
   return (
     <>
@@ -57,7 +69,11 @@ const InvitedDashboard = () => {
                 <TableBody>{invitation.invitee.nickname}</TableBody>
               </Info>
               <Info>
-                <ButtonSet type="acceptAndReject" />
+                <ButtonSet
+                  type="acceptAndReject"
+                  onClickLeft={() => handleInvitationResponse(invitation.id, true)}
+                  onClickRight={() => handleInvitationResponse(invitation.id, false)}
+                />
               </Info>
             </InvitationItem>
           ))}

--- a/components/Table/InvitedDashboard.tsx
+++ b/components/Table/InvitedDashboard.tsx
@@ -2,6 +2,8 @@ import styled from "styled-components";
 import { DeviceSize } from "@/styles/DeviceSize";
 import ButtonSet from "@/components/common/Buttons/ButtonSet";
 import NoInvitation from "@/components/Table/NoInvite";
+import { useEffect, useState } from "react";
+import { getInvitations } from "@/api/invitations";
 
 interface Invitation {
   id: number;
@@ -14,16 +16,29 @@ interface Invitation {
   updatedAt: string;
 }
 
-interface InvitationsListProps {
-  invitations: Invitation[];
-}
+const PAGE_SIZE = 5;
 
-const InvitedDashboard = ({ invitations }: InvitationsListProps) => {
+const InvitedDashboard = () => {
   const tableTitles = ["이름", "초대자", "수락 여부"];
+  const [invitations, setInvitations] = useState<Invitation[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await getInvitations({
+        size: PAGE_SIZE,
+        token:
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNjc1NzE2LCJpc3MiOiJzcC10YXNraWZ5In0.J60KP7YBw6JWhFDqk4u3Pm5g9KSCr0UrTt4GAelAvhI",
+      });
+      if (data && data.invitations) {
+        setInvitations(data.invitations);
+      }
+    };
+    fetchData();
+  }, []);
 
   return (
     <>
-      {invitations ? (
+      {invitations.length > 0 ? (
         <Container>
           <Title>초대받은 대시보드</Title>
           <Header>

--- a/components/common/Buttons/ButtonSet.tsx
+++ b/components/common/Buttons/ButtonSet.tsx
@@ -6,8 +6,8 @@ import styled, { css } from "styled-components";
 interface ButtonProps {
   isDisabled?: boolean;
   $buttonType: keyof typeof TYPES;
-  onClickForward?: () => void;
-  onClickBackward?: () => void;
+  onClickLeft?: () => void;
+  onClickRight?: () => void;
 }
 
 type ButtonCommonProps = Omit<ButtonProps, "$buttonType">;
@@ -17,35 +17,35 @@ interface ButtonSetProps extends ButtonCommonProps {
   children?: ReactNode;
 }
 
-const ButtonSet = ({ type, isDisabled, children, onClickForward, onClickBackward }: ButtonSetProps) => {
+const ButtonSet = ({ type, isDisabled, children, onClickLeft, onClickRight }: ButtonSetProps) => {
   return (
     <ButtonSetContainer type={type}>
       {type === "forwardAndBackward" && (
         <>
-          <Button $buttonType="backward" disabled={isDisabled} onClick={onClickBackward}>
+          <Button $buttonType="backward" disabled={isDisabled} onClick={onClickLeft}>
             <StyledArrowIcon disabled={isDisabled} />
           </Button>
-          <Button $buttonType="forward" disabled={isDisabled} onClick={onClickForward}>
+          <Button $buttonType="forward" disabled={isDisabled} onClick={onClickRight}>
             <StyledArrowIcon disabled={isDisabled} />
           </Button>
         </>
       )}
       {type === "acceptAndReject" && (
         <>
-          <Button $buttonType="accept" disabled={isDisabled}>
+          <Button $buttonType="accept" disabled={isDisabled} onClick={onClickLeft}>
             수락
           </Button>
-          <Button $buttonType="reject" disabled={isDisabled}>
+          <Button $buttonType="reject" disabled={isDisabled} onClick={onClickRight}>
             거절
           </Button>
         </>
       )}
       {type === "modalSet" && (
         <>
-          <Button $buttonType="cancel" disabled={isDisabled}>
+          <Button $buttonType="cancel" disabled={isDisabled} onClick={onClickLeft}>
             취소
           </Button>
-          <Button $buttonType="basic" disabled={isDisabled}>
+          <Button $buttonType="basic" disabled={isDisabled} onClick={onClickRight}>
             {children}
           </Button>
         </>


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
저는 제가 회원가입해서 제껄로 test했어욤

Commit1: getInvitations 이용해서 데이터 불러와서 화면에 출력했습니당
Commit2: 수락 버튼 누를 시 목록에서 없어지며 내 대시보드에 추가, 거절 시 목록에서 사라짐
* 이 과정에서 버튼set 컴포넌트 onclick 타입을 left랑 right로 통일
* 초대 수락, 거절에서 put할 때 inviteAccepted를 리퀘스트 바디 프롭으로 넘겨줘야하는데 셋팅이 안돼있길래 추가했습니다아앙


+🥹아까 api 셋팅하면서 타입이나 데이터필드 이름에 오타가 몇개 있어가지구..그것도 수정했습니당..흐긓ㄱ ㅜㅜ
***

## 📷 ScreenShot
초대 거절은 영상 따로 안올렸는데 잘 작동합니당
api 정말 느림...😀

https://github.com/SWCF-8TEAM/taskify/assets/72639353/e4f5f2e9-ad81-4d8c-9bef-b2a1f543486b

---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
