### PR TITLE
💫  feat: signpage 기능 구현

### DIFF
--- a/api/auth/auth.types.ts
+++ b/api/auth/auth.types.ts
@@ -9,3 +9,8 @@ export interface User {
   };
   accessToken: string;
 }
+
+export interface PostLoginProps {
+  email: string;
+  password: string;
+}

--- a/api/auth/index.ts
+++ b/api/auth/index.ts
@@ -1,12 +1,12 @@
 import instance from "@/api/axios";
 import { ENDPOINTS } from "@/api/config";
-import { User } from "@/api/auth/auth.types";
+import { User, PostLoginProps } from "@/api/auth/auth.types";
 
-export const postLogin = async (): Promise<User | null> => {
+export const postLogin = async ({ email, password }: PostLoginProps): Promise<User | null> => {
   try {
     const res = await instance.post(ENDPOINTS.AUTH.POST, {
-      email: "jieun@codeit.com",
-      password: "asdf1234",
+      email,
+      password,
     });
 
     return res.data;

--- a/api/users/index.ts
+++ b/api/users/index.ts
@@ -1,6 +1,6 @@
 import instance from "@/api/axios";
 import { ENDPOINTS } from "@/api/config";
-import { UserData, PostImageData, PostProfileImageProps } from "@/api/users/users.types";
+import { UserData, PostImageData, PostProfileImageProps, PostUsersProps } from "@/api/users/users.types";
 
 export const getUsers = async ({
   token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTMsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1NzU1MjgsImlzcyI6InNwLXRhc2tpZnkifQ.vPTurAcm35kevcT9alVW2SxsjFcaKqnmd_mpgVwWfRU",
@@ -43,25 +43,13 @@ export const postProfileImage = async ({
   }
 };
 
-export const postUsers = async ({
-  token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTMsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1NzU1MjgsImlzcyI6InNwLXRhc2tpZnkifQ.vPTurAcm35kevcT9alVW2SxsjFcaKqnmd_mpgVwWfRU",
-}: {
-  token: string;
-}): Promise<UserData | null> => {
+export const postUsers = async ({ email, nickname, password }: PostUsersProps): Promise<UserData | null> => {
   try {
-    const res = await instance.post(
-      ENDPOINTS.USERS.POST,
-      {
-        email: "test@gmail.com",
-        nickname: "메롱이",
-        password: "#123ffffff",
-      },
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      },
-    );
+    const res = await instance.post(ENDPOINTS.USERS.POST, {
+      email,
+      nickname,
+      password,
+    });
     return res.data;
   } catch (error: any) {
     console.error(error.response.data.message);

--- a/api/users/users.types.ts
+++ b/api/users/users.types.ts
@@ -15,3 +15,9 @@ export interface PostProfileImageProps {
   image: string;
   token?: string;
 }
+
+export interface PostUsersProps {
+  email: string;
+  nickname: string;
+  password: string;
+}

--- a/components/Modal/AlertModal.tsx
+++ b/components/Modal/AlertModal.tsx
@@ -5,9 +5,10 @@ import styled from "styled-components";
 
 interface AlertProps {
   type: "complete" | "delete" | "confirm" | "cancel";
+  onClick?: () => void;
 }
 
-const AlertModal = ({ type }: AlertProps) => {
+const AlertModal = ({ type, onClick }: AlertProps) => {
   return (
     <Wrapper>
       <Contents>
@@ -16,7 +17,15 @@ const AlertModal = ({ type }: AlertProps) => {
         {type === "confirm" && "정말 삭제하시겠습니까?"}
         {type === "cancel" && "요청이 취소됩니다."}
       </Contents>
-      <ButtonWrapper>{type === "delete" || type === "confirm" ? <ButtonSet type="modalSet">삭제</ButtonSet> : <Button type="modalConfirm">확인</Button>}</ButtonWrapper>
+      <ButtonWrapper>
+        {type === "delete" || type === "confirm" ? (
+          <ButtonSet type="modalSet">삭제</ButtonSet>
+        ) : (
+          <Button onClick={onClick} type="modalConfirm">
+            확인
+          </Button>
+        )}
+      </ButtonWrapper>
     </Wrapper>
   );
 };

--- a/components/Modal/ModalWrapper.tsx
+++ b/components/Modal/ModalWrapper.tsx
@@ -1,0 +1,31 @@
+import { styled } from "styled-components";
+
+const ModalWrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Wrapper>
+      <Container>{children}</Container>
+    </Wrapper>
+  );
+};
+
+export default ModalWrapper;
+
+const Wrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 10;
+`;
+
+const Container = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-50%);
+`;

--- a/components/Sign/SignForm/SignInForm.tsx
+++ b/components/Sign/SignForm/SignInForm.tsx
@@ -2,7 +2,7 @@ import { postLogin } from "@/api/auth";
 import Input from "@/components/Sign/SignInput/Input";
 import PasswordInput from "@/components/Sign/SignInput/PasswordInput";
 import Button from "@/components/common/Buttons/Button";
-import { EMAIL_RULES, PLACEHOLDER, SIGNIN_PASSWORD_RULES } from "@/constants/InputConstant";
+import { EMAIL_RULES, ERROR_MESSAGE, PLACEHOLDER, SIGNIN_PASSWORD_RULES } from "@/constants/InputConstant";
 import { useRouter } from "next/router";
 import { Controller, useForm } from "react-hook-form";
 import styled from "styled-components";
@@ -23,8 +23,8 @@ const SignInForm = () => {
           router.push("/mydashboard");
           return;
         }
-        setError("email", { message: "이메일을 확인해주세요." });
-        setError("password", { message: "비밀번호를 확인해주세요." });
+        setError("email", { message: ERROR_MESSAGE.emailCheck });
+        setError("password", { message: ERROR_MESSAGE.passwordCheck });
       })}
     >
       <Controller

--- a/components/Sign/SignForm/SignInForm.tsx
+++ b/components/Sign/SignForm/SignInForm.tsx
@@ -12,8 +12,8 @@ const SignInForm = () => {
     defaultValues: { email: "", password: "" },
     mode: "onBlur",
   });
-
   const router = useRouter();
+  
   return (
     <StyledForm
       onSubmit={handleSubmit(async (data) => {

--- a/components/Sign/SignForm/SignInForm.tsx
+++ b/components/Sign/SignForm/SignInForm.tsx
@@ -1,17 +1,32 @@
+import { postLogin } from "@/api/auth";
 import Input from "@/components/Sign/SignInput/Input";
 import PasswordInput from "@/components/Sign/SignInput/PasswordInput";
-import { EMAIL_RULES, SIGNIN_PASSWORD_RULES, PLACEHOLDER } from "@/constants/InputConstant";
+import Button from "@/components/common/Buttons/Button";
+import { EMAIL_RULES, PLACEHOLDER, SIGNIN_PASSWORD_RULES } from "@/constants/InputConstant";
+import { useRouter } from "next/router";
 import { Controller, useForm } from "react-hook-form";
 import styled from "styled-components";
 
 const SignInForm = () => {
-  const { control, handleSubmit, watch, setError } = useForm({
+  const { control, handleSubmit, setError } = useForm({
     defaultValues: { email: "", password: "" },
     mode: "onBlur",
   });
 
+  const router = useRouter();
   return (
-    <StyledForm>
+    <StyledForm
+      onSubmit={handleSubmit(async (data) => {
+        const res = await postLogin({ email: data.email, password: data.password });
+        if (res !== null) {
+          localStorage.setItem("accessToken", res.accessToken);
+          router.push("/mydashboard");
+          return;
+        }
+        setError("email", { message: "이메일을 확인해주세요." });
+        setError("password", { message: "비밀번호를 확인해주세요." });
+      })}
+    >
       <Controller
         control={control}
         name="email"
@@ -28,6 +43,9 @@ const SignInForm = () => {
           <PasswordInput label="비밀번호" {...field} placeholder={PLACEHOLDER.password} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
         )}
       />
+      <ButtonWrapper>
+        <Button type="login">로그인</Button>
+      </ButtonWrapper>
     </StyledForm>
   );
 };
@@ -40,4 +58,8 @@ const StyledForm = styled.form`
   display: flex;
   flex-direction: column;
   row-gap: 1.6rem;
+`;
+const ButtonWrapper = styled.div`
+  margin-top: 2rem;
+  margin-bottom: 2.4rem;
 `;

--- a/components/Sign/SignForm/SignUpForm.tsx
+++ b/components/Sign/SignForm/SignUpForm.tsx
@@ -16,7 +16,6 @@ const SignUpForm = () => {
     defaultValues: { email: "", nickname: "", password: "", confirmPassword: "" },
     mode: "onBlur",
   });
-
   const router = useRouter();
 
   const handleCloseModal = () => {

--- a/components/Sign/SignForm/SignUpForm.tsx
+++ b/components/Sign/SignForm/SignUpForm.tsx
@@ -1,64 +1,94 @@
+import { postUsers } from "@/api/users";
+import AlertModal from "@/components/Modal/AlertModal";
+import ModalWrapper from "@/components/Modal/ModalWrapper";
 import Input from "@/components/Sign/SignInput/Input";
 import PasswordInput from "@/components/Sign/SignInput/PasswordInput";
+import Button from "@/components/common/Buttons/Button";
 import { ERROR_MESSAGE, NICKNAME_RULES, SIGNUP_PASSWORD_RULES, PLACEHOLDER } from "@/constants/InputConstant";
+import { useModal } from "@/hooks/useModal";
+import { useRouter } from "next/router";
 import { Controller, useForm } from "react-hook-form";
 import styled from "styled-components";
 
-// 나머지 에러는 페이지 만들때 수정!?
 const SignUpForm = () => {
+  const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const { control, handleSubmit, watch, setError } = useForm({
     defaultValues: { email: "", nickname: "", password: "", confirmPassword: "" },
     mode: "onBlur",
   });
 
+  const router = useRouter();
+
+  const handleCloseModal = () => {
+    closeModalFunc();
+    router.push("/signin");
+  };
   return (
-    <StyledForm>
-      <Controller
-        control={control}
-        name="email"
-        rules={{
-          required: ERROR_MESSAGE.emailRequired,
-          pattern: { value: /\S+@\S+\.\S+/, message: ERROR_MESSAGE.emailInvalid },
-        }}
-        render={({ field, fieldState }) => (
-          <Input label="이메일" {...field} placeholder={PLACEHOLDER.email} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
-        )}
-      />
-      <Controller
-        control={control}
-        name="nickname"
-        rules={NICKNAME_RULES}
-        render={({ field, fieldState }) => (
-          <Input label="닉네임" {...field} placeholder={PLACEHOLDER.nickname} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
-        )}
-      />
-      <Controller
-        control={control}
-        name="password"
-        rules={SIGNUP_PASSWORD_RULES}
-        render={({ field, fieldState }) => (
-          <PasswordInput label="비밀번호" {...field} placeholder={PLACEHOLDER.signUpPassword} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
-        )}
-      />
-      <Controller
-        control={control}
-        name="confirmPassword"
-        rules={{
-          required: ERROR_MESSAGE.confirmPasswordRequired,
-          validate: {
-            isMatch: (value) => {
-              if (value !== watch("password")) {
-                return ERROR_MESSAGE.confirmPasswordCheck;
-              }
-              return true;
+    <>
+      <StyledForm
+        onSubmit={handleSubmit(async (data) => {
+          const res = await postUsers({ email: data.email, password: data.password, nickname: data.nickname });
+          if (res !== null) {
+            openModalFunc();
+          }
+          setError("email", { message: ERROR_MESSAGE.emailDuplicate });
+        })}
+      >
+        <Controller
+          control={control}
+          name="email"
+          rules={{
+            required: ERROR_MESSAGE.emailRequired,
+            pattern: { value: /\S+@\S+\.\S+/, message: ERROR_MESSAGE.emailInvalid },
+          }}
+          render={({ field, fieldState }) => (
+            <Input label="이메일" {...field} placeholder={PLACEHOLDER.email} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          control={control}
+          name="nickname"
+          rules={NICKNAME_RULES}
+          render={({ field, fieldState }) => (
+            <Input label="닉네임" {...field} placeholder={PLACEHOLDER.nickname} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          control={control}
+          name="password"
+          rules={SIGNUP_PASSWORD_RULES}
+          render={({ field, fieldState }) => (
+            <PasswordInput label="비밀번호" {...field} placeholder={PLACEHOLDER.signUpPassword} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
+          )}
+        />
+        <Controller
+          control={control}
+          name="confirmPassword"
+          rules={{
+            required: ERROR_MESSAGE.confirmPasswordRequired,
+            validate: {
+              isMatch: (value) => {
+                if (value !== watch("password")) {
+                  return ERROR_MESSAGE.confirmPasswordCheck;
+                }
+                return true;
+              },
             },
-          },
-        }}
-        render={({ field, fieldState }) => (
-          <PasswordInput label="비밀번호 확인" {...field} placeholder={PLACEHOLDER.signUpPassword} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
-        )}
-      />
-    </StyledForm>
+          }}
+          render={({ field, fieldState }) => (
+            <PasswordInput label="비밀번호 확인" {...field} placeholder={PLACEHOLDER.signUpPassword} hasError={Boolean(fieldState.error)} errorText={fieldState.error?.message} />
+          )}
+        />
+        <ButtonWrapper>
+          <Button type="login">가입하기</Button>
+        </ButtonWrapper>
+      </StyledForm>
+      {isModalOpen && (
+        <ModalWrapper>
+          <AlertModal type="complete" onClick={handleCloseModal} />
+        </ModalWrapper>
+      )}
+    </>
   );
 };
 
@@ -70,4 +100,9 @@ const StyledForm = styled.form`
   display: flex;
   flex-direction: column;
   row-gap: 1.6rem;
+`;
+
+const ButtonWrapper = styled.div`
+  margin-top: 2rem;
+  margin-bottom: 2.4rem;
 `;

--- a/components/Sign/SignInput/PasswordInput.tsx
+++ b/components/Sign/SignInput/PasswordInput.tsx
@@ -15,7 +15,7 @@ const PasswordInput = forwardRef<HTMLInputElement, InputProps>(({ label, value, 
   return (
     <InputContainer>
       <Input ref={ref} label={label} type={inputType} value={value} hasError={hasError} errorText={errorText} onChange={onChange} onBlur={onBlur} placeholder={placeholder} />
-      <ToggleButton onClick={toggleButton}>{isPasswordVisible ? <VisibilityOff /> : <VisibilityOn />}</ToggleButton>
+      <ToggleButton onClick={toggleButton}>{isPasswordVisible ? <VisibilityOn /> : <VisibilityOff />}</ToggleButton>
     </InputContainer>
   );
 });

--- a/components/common/Nav/SignButton.tsx
+++ b/components/common/Nav/SignButton.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 const SignButton = () => {
   return (
     <Wrapper>
-      <Button href="/login">로그인</Button>
+      <Button href="/signin">로그인</Button>
       <Button href="/signup">회원가입</Button>
     </Wrapper>
   );

--- a/constants/InputConstant.ts
+++ b/constants/InputConstant.ts
@@ -10,6 +10,7 @@ export const ERROR_MESSAGE = {
   emailRequired: "이메일을 입력해 주세요.",
   emailInvalid: "이메일 형식으로 작성해 주세요.",
   emailCheck: "이메일을 확인해 주세요.",
+  emailDuplicate: "이미 사용중인 이메일입니다.",
 
   passwordRequired: "비밀번호를 입력해 주세요.",
   signinPasswordInvalid: "8자 이상 입력해 주세요.",

--- a/hooks/useModal.ts
+++ b/hooks/useModal.ts
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+export const useModal = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModalFunc = () => {
+    setIsModalOpen(true);
+  };
+  const closeModalFunc = () => {
+    setIsModalOpen(false);
+  };
+
+  return { isModalOpen, openModalFunc, closeModalFunc };
+};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,4 @@
 import MainSection from "@/components/Landing/MainSection";
-import TaskModal from "@/components/Modal/TaskModal";
 import MainNav from "@/components/common/Nav/MainNav";
 import Head from "next/head";
 
@@ -10,9 +9,8 @@ export default function Home() {
         <meta name="description" content="Taskify helps you manage your tasks with ease. Join now and get organized!" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      {/* <MainNav />
-      <MainSection /> */}
-      <TaskModal />
+      <MainNav />
+      <MainSection />
     </>
   );
 }

--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -1,6 +1,5 @@
 import MainLogo from "@/assets/icons/main-logo.svg";
 import SignInForm from "@/components/Sign/SignForm/SignInForm";
-import Button from "@/components/common/Buttons/Button";
 import Link from "next/link";
 import styled from "styled-components";
 
@@ -12,9 +11,6 @@ const SignInPage = () => {
       </Link>
       <Greeting>오늘도 만나서 반가워요!</Greeting>
       <SignInForm />
-      <ButtonWrapper>
-        <Button type="login">로그인</Button>
-      </ButtonWrapper>
       <CheckMembership>
         {"회원이 아니신가요? "}
         <Link href="/signup">
@@ -46,11 +42,6 @@ const Greeting = styled.p`
   font-size: 2rem;
   font-weight: 500;
   color: var(--Black33);
-`;
-
-const ButtonWrapper = styled.div`
-  margin-top: 2rem;
-  margin-bottom: 2.4rem;
 `;
 
 const CheckMembership = styled.p`

--- a/pages/signup/index.tsx
+++ b/pages/signup/index.tsx
@@ -14,9 +14,6 @@ const SignUpPage = () => {
       <SignUpFormWrapper>
         <SignUpForm />
       </SignUpFormWrapper>
-      <ButtonWrapper>
-        <Button type="login">가입하기</Button>
-      </ButtonWrapper>
       <CheckMembership>
         {"이미 가입하셨나요? "}
         <Link href="/signin">
@@ -52,11 +49,6 @@ const Greeting = styled.p`
 
 const SignUpFormWrapper = styled.div`
   display: flex;
-`;
-
-const ButtonWrapper = styled.div`
-  margin-top: 2rem;
-  margin-bottom: 2.4rem;
 `;
 
 const CheckMembership = styled.p`


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- 로그인 성공 시 토큰을 localStorage에 저장하고, mydashboard페이지로 이동합니다.(cookie에 대해선 더 공부해볼게요)
- 로그인 실패 시 '이메일을 확인해주세요' '비밀번호를 확인해주세요' 에러를 보여줍니다.

- 회원가입 성공시 성공 모달을 보여줍니다.
- useModal hook과 공통으로 쓰이는 ModalWrapper 컴포넌트를 만들었습니당(애용해주세용)
- 이메일이 중복일시 에러를 보여줍니다.

- 일반적으로 form하면 button도 포함이라 생각해서 button도 SignInForm, SignUpForm으로 옮겨줬습니다. 이로써 클릭하면 onSubmit()이 실행돼요!
***

## 📷 ScreenShot
---
<img width="676" alt="스크린샷 2023-12-28 오후 5 42 45" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/b41df76e-d64f-4ee4-8a79-5526deede5d1">
<img width="545" alt="스크린샷 2023-12-28 오후 5 43 17" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/ee38a392-c756-4f3f-be0a-e94e8093ffb8">
<img width="813" alt="스크린샷 2023-12-28 오후 5 43 30" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/18930bda-3bb5-4e3e-a434-00462e27bdc7">



## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
