### PR TITLE
💫feat: 대시보드 변경 버튼 클릭시 토스트 띄우기 

### DIFF
--- a/components/Dashboard/Column/Columns.tsx
+++ b/components/Dashboard/Column/Columns.tsx
@@ -5,6 +5,7 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import { useEffect, useState } from "react";
 import { Z_INDEX } from "@/styles/ZindexStyles";
 import styled from "styled-components";
+import { toast } from "react-toastify";
 
 interface Column {
   createdAt: string;

--- a/components/Modal/ToastModal.tsx
+++ b/components/Modal/ToastModal.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { toast, ToastContainer } from "react-toastify"; // ToastContainer를 추가로 가져옵니다.
+import { ToastContainer } from "react-toastify"; // ToastContainer를 추가로 가져옵니다.
 import styled from "styled-components";
 import { DeviceSize } from "@/styles/DeviceSize";
 import "react-toastify/dist/ReactToastify.css";

--- a/components/Modal/ToastModal.tsx
+++ b/components/Modal/ToastModal.tsx
@@ -5,11 +5,8 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import "react-toastify/dist/ReactToastify.css";
 
 function ToastModal() {
-  const openToast = () => toast("변경이 완료되었습니다.");
-
   return (
     <div>
-      <button onClick={openToast}>테스트버튼</button>
       <StyledContainer position="bottom-center" limit={1} closeButton={true} autoClose={4000} hideProgressBar />
     </div>
   );

--- a/components/Modal/ToastModal.tsx
+++ b/components/Modal/ToastModal.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { toast, ToastContainer } from "react-toastify"; // ToastContainer를 추가로 가져옵니다.
+import styled from "styled-components";
+import { DeviceSize } from "@/styles/DeviceSize";
+import "react-toastify/dist/ReactToastify.css";
+
+function ToastModal() {
+  const openToast = () => toast("변경이 완료되었습니다.");
+
+  return (
+    <div>
+      <button onClick={openToast}>테스트버튼</button>
+      <StyledContainer position="bottom-center" limit={1} closeButton={true} autoClose={4000} hideProgressBar />
+    </div>
+  );
+}
+
+export default ToastModal;
+
+const StyledContainer = styled(ToastContainer)`
+  &&&.Toastify__toast-container {
+    width: 300px;
+
+    @media (max-width: ${DeviceSize.mobile}) {
+      width: 200px;
+    }
+  }
+
+  .Toastify__toast {
+    border-radius: 8px;
+
+    text-align: center;
+
+    background-color: var(--Main);
+    color: #fff;
+  }
+
+  .Toastify__toast-body {
+    padding: 1.4rem 2rem;
+
+    font-size: 1.2rem;
+    font-weight: 500;
+
+    @media (max-width: ${DeviceSize.mobile}) {
+      padding: 1.2rem 1.6rem;
+    }
+  }
+
+  .Toastify__progress-bar {
+    background-color: #fff;
+  }
+`;

--- a/components/Modal/ToastModal.tsx
+++ b/components/Modal/ToastModal.tsx
@@ -16,10 +16,10 @@ export default ToastModal;
 
 const StyledContainer = styled(ToastContainer)`
   &&&.Toastify__toast-container {
-    width: 300px;
+    width: 30rem;
 
     @media (max-width: ${DeviceSize.mobile}) {
-      width: 200px;
+      width: 20rem;
     }
   }
 

--- a/components/Table/EditDashboard.tsx
+++ b/components/Table/EditDashboard.tsx
@@ -1,8 +1,18 @@
 import styled from "styled-components";
+import React, { useState } from "react";
 import DashBoardColor from "../common/Chip/DashBoardColor";
 import { DeviceSize } from "@/styles/DeviceSize";
+import ToastModal from "../Modal/ToastModal";
+import { toast } from "react-toastify";
 
 const EditDashboard = () => {
+  const [toastVisible, setToastVisible] = useState(false);
+
+  const handleClick = () => {
+    toast("변경이 완료되었습니다.");
+    setToastVisible((prev) => !prev);
+  };
+
   return (
     <Wrapper>
       <Header>
@@ -14,7 +24,8 @@ const EditDashboard = () => {
         <Input placeholder="변경할 이름을 입력해 주세요." />
       </Form>
       <ButtonWrapper>
-        <Button>변경</Button>
+        <Button onClick={handleClick}> 변경</Button>
+        {toastVisible && <ToastModal />}
       </ButtonWrapper>
     </Wrapper>
   );

--- a/components/Table/EditDashboard.tsx
+++ b/components/Table/EditDashboard.tsx
@@ -1,8 +1,8 @@
 import styled from "styled-components";
 import React, { useState } from "react";
-import DashBoardColor from "../common/Chip/DashBoardColor";
+import DashBoardColor from "@/components/common/Chip/DashBoardColor";
 import { DeviceSize } from "@/styles/DeviceSize";
-import ToastModal from "../Modal/ToastModal";
+import ToastModal from "@/components/Modal/ToastModal";
 import { toast } from "react-toastify";
 
 const EditDashboard = () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.49.2",
         "react-icons": "^4.12.0",
+        "react-toastify": "^9.1.3",
         "styled-components": "^6.1.1",
         "styled-reset": "^4.5.1"
       },
@@ -3308,6 +3309,14 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6280,6 +6289,18 @@
         "@popperjs/core": "^2.0.0",
         "react": "^16.8.0 || ^17 || ^18",
         "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.49.2",
     "react-icons": "^4.12.0",
+    "react-toastify": "^9.1.3",
     "styled-components": "^6.1.1",
     "styled-reset": "^4.5.1"
   },

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -3,12 +3,14 @@ import Columns from "@/components/Dashboard/Column/Columns";
 
 import SideMenu from "@/components/common/SideMenu/SideMenu";
 import DashboardNav from "@/components/common/Nav/DashboardNav";
+import ToastModal from "@/components/Modal/ToastModal";
 
 const DashBoardPage = () => {
   return (
     <>
       <DashboardNav />
-      <SideMenu />
+      <ToastModal />
+      {/* <SideMenu /> */}
       <ColumnWrapper>
         <Columns />
       </ColumnWrapper>

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -1,16 +1,13 @@
 import { styled } from "styled-components";
 import Columns from "@/components/Dashboard/Column/Columns";
-
 import SideMenu from "@/components/common/SideMenu/SideMenu";
 import DashboardNav from "@/components/common/Nav/DashboardNav";
-import ToastModal from "@/components/Modal/ToastModal";
 
 const DashBoardPage = () => {
   return (
     <>
       <DashboardNav />
-      <ToastModal />
-      {/* <SideMenu /> */}
+      <SideMenu />
       <ColumnWrapper>
         <Columns />
       </ColumnWrapper>


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
-대시보트 변경 버튼 클릭시 토스트가 띄워지도록 했습니다 !!
-4초 뒤에 사라지거나, 클릭시 사라집니다 
***

## 📷 ScreenShot
---
![2023-12-28 18;32;58](https://github.com/SWCF-8TEAM/taskify/assets/144667455/1b57e5ea-e2c5-45de-834d-f87e3b70c35c)

![toast-modal_1](https://github.com/SWCF-8TEAM/taskify/assets/144667455/8d8a339a-7bdf-4124-a267-d175a8895a89)

![toast-modal_2](https://github.com/SWCF-8TEAM/taskify/assets/144667455/0f9f5453-aef1-466f-9327-f69c9551619e)



## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
