### PR TITLE
💫feat: boardId 페이지의 카드 목록을 목데이터 → API를 받도록 수정

### DIFF
--- a/api/cards/cards.types.ts
+++ b/api/cards/cards.types.ts
@@ -11,7 +11,7 @@ export interface Card {
   };
   imageUrl: string;
   teamId: string;
-  columnId: string;
+  columnId: number;
   createdAt: string;
   updatedAt: string;
 }

--- a/api/comments/comments.types.ts
+++ b/api/comments/comments.types.ts
@@ -5,7 +5,7 @@ export interface Comment {
   updatedAt: string;
   cardId: number;
   author: {
-    profileImageUrl: boolean;
+    profileImageUrl: string;
     nickname: string;
     id: number;
   };

--- a/components/Dashboard/Card/Card.tsx
+++ b/components/Dashboard/Card/Card.tsx
@@ -1,12 +1,13 @@
 import CalenderIcon from "@/assets/icons/calender.svg";
 import Tag from "@/components/common/Chip/Tag";
-import { getCardsResponse } from "@/components/Dashboard/Column/Column";
+// import { getCardsResponse } from "@/components/Dashboard/Column/Column";
 import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { formatDate } from "@/utils/FormatDate";
 import styled from "styled-components";
+import { Card } from "@/api/cards/cards.types";
 
-const Card = ({ cardData }: { cardData: getCardsResponse }) => {
+const Card = ({ cardData }: { cardData: Card }) => {
   return (
     <Wrapper>
       {cardData.imageUrl && <CardImage cardimage={cardData.imageUrl || null} />}

--- a/components/Dashboard/Column/Column.tsx
+++ b/components/Dashboard/Column/Column.tsx
@@ -1,51 +1,36 @@
-import instance from "@/api/axios";
 import Card from "@/components/Dashboard/Card/Card";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import ColumnHeader from "@/components/Dashboard/Column/ColumnHeader";
-import { MOCK_DATA } from "@/components/Dashboard/Column/Columns";
 import Button from "@/components/common/Buttons/Button";
 import { DeviceSize } from "@/styles/DeviceSize";
+import { getCardList } from "@/api/cards";
+import { Card as CardData } from "@/api/cards/cards.types";
 
 interface ColumnProps {
   columnId: number;
   title: string;
 }
 
-export interface getCardsResponse {
-  assignee: { id: number; nickname: string; profileImageUrl: string | null };
-  columnId: number;
-  createdAt: string;
-  dashboardId: number;
-  description: string;
-  dueDate: string;
-  id: number;
-  imageUrl: string;
-  tags: string[];
-  teamId: string;
-  title: string;
-  updatedAt: string;
-}
-
 const Column = ({ columnId, title }: ColumnProps) => {
-  const [cards, setCards] = useState<getCardsResponse[]>([]);
+  const [cards, setCards] = useState<CardData[]>([]);
 
   useEffect(() => {
-    const getCards = async () => {
-      const res = await instance.get("/cards", {
-        params: {
-          columnId,
-        },
-        headers: {
-          Authorization: `Bearer ${MOCK_DATA.token}`,
-        },
+    const loadCardList = async () => {
+      const res = await getCardList({
+        size: 10,
+        cursorId: null,
+        columnId,
+        token:
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjE2LCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNzQxODYxLCJpc3MiOiJzcC10YXNraWZ5In0.onJAVE-0l39MjS77mTbfnS6UMU5bWMkVgBKlA-rs03U",
       });
-      const cards = res.data.cards;
-      setCards(() => {
-        return [...cards];
-      });
+
+      if (res !== null) {
+        setCards(res?.cards);
+      }
     };
-    getCards();
+
+    loadCardList();
   }, []);
 
   return (

--- a/components/Dashboard/Column/Columns.tsx
+++ b/components/Dashboard/Column/Columns.tsx
@@ -5,40 +5,26 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import { useEffect, useState } from "react";
 import { Z_INDEX } from "@/styles/ZindexStyles";
 import styled from "styled-components";
-
-interface Column {
-  createdAt: string;
-  dashboardId: number;
-  id: number;
-  teamId: string;
-  title: string;
-  updatedAt: string;
-}
-export const MOCK_DATA = {
-  dashboardId: 217,
-  token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTMsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1MTU1OTIsImlzcyI6InNwLXRhc2tpZnkifQ.WXLHBnKbOg00qIuVgOb-FSlCuq2dzqRLOP1OUy2VQjc",
-};
+import { getColumns } from "@/api/columns";
+import { Columns as ColumnsData } from "@/api/columns/columns.types";
 
 const Columns = () => {
-  const [columns, setColumns] = useState<Column[]>([]);
+  const [columns, setColumns] = useState<ColumnsData[]>([]);
   const [isClicked, setIsClicked] = useState(false);
 
   useEffect(() => {
-    const getColumns = async () => {
-      const res = await instance.get("/columns", {
-        params: {
-          dashboardId: MOCK_DATA.dashboardId,
-        },
-        headers: {
-          Authorization: `Bearer ${MOCK_DATA.token}`,
-        },
+    const loadColumnsData = async () => {
+      const res = await getColumns({
+        dashboardId: 399,
+        token:
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjE2LCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNzQxODYxLCJpc3MiOiJzcC10YXNraWZ5In0.onJAVE-0l39MjS77mTbfnS6UMU5bWMkVgBKlA-rs03U",
       });
-      const columns = res.data.data;
+      const columns = res?.data;
       setColumns(() => {
         return [...columns];
       });
     };
-    getColumns();
+    loadColumnsData();
   }, []);
 
   return (


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description

-카드 목록을 (목데이터를 삭제하고) API를 받도록 수정했습니다!
***

## 📷 ScreenShot
---
![dashboard-api](https://github.com/SWCF-8TEAM/taskify/assets/144667455/82c15795-3772-4086-926b-8c91e344ce81)


## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
