### PR TITLE
💫 feat: 초대받은 대시보드 변경사항 시 페이지 전체가 랜더링 되도록 전역변수 사용

### DIFF
--- a/api/dashboards/index.ts
+++ b/api/dashboards/index.ts
@@ -89,7 +89,7 @@ export const getDashboardInvitations = async ({
   }
 };
 
-export const getDashboardList = async ({ navigationMethod, size = 5, cursorId, token }: GetDashboardListProps): Promise<GetDashboardListData | null> => {
+export const getDashboardList = async ({ navigationMethod, size, cursorId, token }: GetDashboardListProps): Promise<GetDashboardListData | null> => {
   try {
     const res = await instance.get(ENDPOINTS.DASHBOARDS.GET_LIST, {
       params: {

--- a/components/Modal/ModalContainer.tsx
+++ b/components/Modal/ModalContainer.tsx
@@ -22,7 +22,7 @@ const ModalContainer = ({ title, label, buttonType, onClose }: ModalProps) => {
         </ColorSelectorWrapper>
       )}
       <ButtonWrapper>
-        <ButtonSet type="modalSet" onClickCancel={onClose}>
+        <ButtonSet type="modalSet" onClickLeft={onClose}>
           {buttonType}
         </ButtonSet>
       </ButtonWrapper>

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -19,6 +19,7 @@ export interface Dashboards {
   updatedAt: string;
   createdByMe: boolean;
 }
+
 const PAGE_SIZE = 30;
 
 const MyDashboardList = () => {

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -6,6 +6,9 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { styled } from "styled-components";
 import ModalContainer from "@/components/Modal/ModalContainer";
+import { useAtom } from "jotai";
+import { invitationsAtom } from "@/states/atoms";
+import { Z_INDEX } from "@/styles/ZindexStyles";
 
 export interface Dashboards {
   id: number;
@@ -16,13 +19,14 @@ export interface Dashboards {
   updatedAt: string;
   createdByMe: boolean;
 }
-const PAGE_SIZE = 5;
+const PAGE_SIZE = 30;
 
 const MyDashboardList = () => {
   const [dashboards, setDashboards] = useState<Dashboards[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPageCount, setTotalPageCount] = useState(1);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [invitations] = useAtom(invitationsAtom); // 초대 목록!!
 
   const handleOpenModal = () => {
     setIsModalOpen(true);
@@ -37,19 +41,20 @@ const MyDashboardList = () => {
       const res = await getDashboardList({
         size: PAGE_SIZE,
         token:
-          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTMsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1NzU1MjgsImlzcyI6InNwLXRhc2tpZnkifQ.vPTurAcm35kevcT9alVW2SxsjFcaKqnmd_mpgVwWfRU",
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNzQ4NDU5LCJpc3MiOiJzcC10YXNraWZ5In0.WYQWWikKqILh4vWyiDSCs0HDO-3TvKg7ci19-NUVexk",
         navigationMethod: "pagination",
         page: currentPage,
       });
 
-      const resDashboards = res?.dashboards;
-      const totalCount = res?.totalCount;
+      const resDashboards = res?.dashboards || [];
+      const totalCount = res?.totalCount || 0;
 
-      setDashboards(() => [...resDashboards]);
+      setDashboards(resDashboards);
       setTotalPageCount(Math.ceil(totalCount / PAGE_SIZE));
     };
     loadDashboardList();
-  }, [currentPage]);
+  }, [currentPage, invitations]);
+
   return (
     <Wrapper>
       <Container>
@@ -116,14 +121,18 @@ const Wrapper = styled.div`
 `;
 
 const ModalBackdrop = styled.div`
+  width: 100%;
+  height: 100%;
+
   position: fixed;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 10;
+
+  background-color: rgba(0, 0, 0, 0.5);
+
+  z-index: ${Z_INDEX.MyDashboardList_ModalBackdrop};
 `;

--- a/components/Table/InvitedDashboard.tsx
+++ b/components/Table/InvitedDashboard.tsx
@@ -2,31 +2,22 @@ import styled from "styled-components";
 import { DeviceSize } from "@/styles/DeviceSize";
 import ButtonSet from "@/components/common/Buttons/ButtonSet";
 import NoInvitation from "@/components/Table/NoInvite";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { getInvitations } from "@/api/invitations";
 import { putInvitations } from "@/api/invitations";
+import { useAtom } from "jotai";
+import { invitationsAtom } from "@/states/atoms";
 
-interface Invitation {
-  id: number;
-  inviterUserId: number;
-  teamId: string;
-  dashboard: { title: string; id: number };
-  invitee: { nickname: string; id: number };
-  inviteAccepted: boolean;
-  createdAt: string;
-  updatedAt: string;
-}
-
-const PAGE_SIZE = 5;
+const PAGE_SIZE = 10;
 
 const InvitedDashboard = () => {
   const tableTitles = ["이름", "초대자", "수락 여부"];
-  const [invitations, setInvitations] = useState<Invitation[]>([]);
+  const [invitations, setInvitations] = useAtom(invitationsAtom);
 
-  const fetchData = async () => {
+  const loadInvitations = async () => {
     const data = await getInvitations({
       size: PAGE_SIZE,
-      token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNjc1NzE2LCJpc3MiOiJzcC10YXNraWZ5In0.J60KP7YBw6JWhFDqk4u3Pm5g9KSCr0UrTt4GAelAvhI",
+      token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNzQ4NDU5LCJpc3MiOiJzcC10YXNraWZ5In0.WYQWWikKqILh4vWyiDSCs0HDO-3TvKg7ci19-NUVexk",
     });
     if (data && data.invitations) {
       setInvitations(data.invitations);
@@ -34,17 +25,17 @@ const InvitedDashboard = () => {
   };
 
   useEffect(() => {
-    fetchData();
+    loadInvitations();
   }, []);
 
   const handleInvitationResponse = async (invitationId: number, accept: boolean) => {
     const updatedInvitation = await putInvitations({
       invitationId,
-      token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNjc1NzE2LCJpc3MiOiJzcC10YXNraWZ5In0.J60KP7YBw6JWhFDqk4u3Pm5g9KSCr0UrTt4GAelAvhI",
+      token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNzQ4NDU5LCJpc3MiOiJzcC10YXNraWZ5In0.WYQWWikKqILh4vWyiDSCs0HDO-3TvKg7ci19-NUVexk",
       inviteAccepted: accept,
     });
     if (updatedInvitation) {
-      fetchData();
+      loadInvitations();
     }
   };
 

--- a/components/common/Nav/Profile.tsx
+++ b/components/common/Nav/Profile.tsx
@@ -52,7 +52,7 @@ const Profile = ({ profileImageUrl, nickname }: ProfileProps) => {
         </NoProfileImageWrapper>
       )}
       <Name>{nickname}</Name>
-      <StyledArrowIcon active={activeDropdown === "profile"} onClick={toggleKebabMenu} />
+      <StyledArrowIcon active={activeDropdown === "profile" ? "true" : undefined} onClick={toggleKebabMenu} />
       {activeDropdown === "profile" && (
         <DropdownMenu>
           <MenuItem onClick={() => navigateTo("/mydashboard")}>

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -3,17 +3,28 @@ import Crown from "@/assets/icons/crown.svg";
 import LogoButton from "@/components/common/Buttons/LogoButton";
 import { DeviceSize } from "@/styles/DeviceSize";
 import styled from "styled-components";
-import dashboardData from "./mockData";
 import ArrowButton from "@/assets/icons/arrow-forward.svg";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Z_INDEX } from "@/styles/ZindexStyles";
+import { getDashboardList } from "@/api/dashboards";
+import { useAtom } from "jotai";
+import { invitationsAtom } from "@/states/atoms";
 
 interface DashboardProps {
   color: string;
   title: string;
   createdByMe?: boolean;
   closePopup?: () => void;
+}
+export interface Dashboards {
+  id: number;
+  title: string;
+  color: string;
+  userId: number;
+  createdAt: string;
+  updatedAt: string;
+  createdByMe: boolean;
 }
 
 const Dashboard = ({ color, title, createdByMe }: DashboardProps) => {
@@ -28,8 +39,24 @@ const Dashboard = ({ color, title, createdByMe }: DashboardProps) => {
 };
 
 const SideMenu = () => {
-  const data = dashboardData.dashboards;
   const [isPopupVisible, setIsPopupVisible] = useState(false);
+  const [cursorId, setCursorId] = useState(1);
+  const [dashboards, setDashboards] = useState<Dashboards[]>([]);
+  const [invitations] = useAtom(invitationsAtom); // 초대 목록!!
+
+  useEffect(() => {
+    const loadDashboardList = async () => {
+      const res = await getDashboardList({
+        token:
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTgxLCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNzQ4NDU5LCJpc3MiOiJzcC10YXNraWZ5In0.WYQWWikKqILh4vWyiDSCs0HDO-3TvKg7ci19-NUVexk",
+        navigationMethod: "infiniteScroll",
+      });
+      if (res && res.dashboards) {
+        setDashboards(res.dashboards); // 로드한 데이터를 상태에 저장
+      }
+    };
+    loadDashboardList();
+  }, [invitations]);
 
   const togglePopup = () => {
     setIsPopupVisible((prev) => !prev);
@@ -46,7 +73,7 @@ const SideMenu = () => {
       {isPopupVisible && (
         <Popup>
           <DashboardList>
-            {data.map((dashboard, key) => {
+            {dashboards.map((dashboard, key) => {
               return <Dashboard key={key} color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} />;
             })}
           </DashboardList>
@@ -57,7 +84,7 @@ const SideMenu = () => {
         <StyledAddButton alt="추가 버튼" width={20} height={20} />
       </HeaderWrapper>
       <DashboardList>
-        {data.map((dashboard, key) => {
+        {dashboards.map((dashboard, key) => {
           return <Dashboard key={key} color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} />;
         })}
       </DashboardList>

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -1,6 +1,9 @@
 import { atom } from "jotai";
+import { Invitation } from "@/api/invitations/invitations.types";
 
 export const selectedColorAtom = atom("");
 
 // 현재 활성화된 드롭다운의 식별자를 저장하는 아톰
 export const activeDropdownAtom = atom<string | null>(null);
+
+export const invitationsAtom = atom<Invitation[]>([]);

--- a/styles/ZindexStyles.ts
+++ b/styles/ZindexStyles.ts
@@ -10,4 +10,5 @@ export const Z_INDEX = {
   SideMenu_Popup: 999,
   Column_ButtonWrapper: 1,
   TaskModal_StyledKebabModal: 1000,
+  MyDashboardList_ModalBackdrop: 10,
 };


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- 초대받은 대시보드 수락, 거절 버튼 클릭 시 위에 위치한 내가 참여하고 있는 대시보드랑 사이드메뉴도 렌더링 되게 했습니다!
- jotai사용해서 invitations변수(초대 목록)를 전역에 놨구용..이 변수에 변경사항이 생기면  다시 재 렌더링 됩니다아아아
- 사이드메뉴 랜더링되게 전역변수로만 변경하려했는데 아직 데이터 연동이 안돼있길래 제가 했..ㅎㅎ 왕관은 안했어요! (아 왕관은 이미 구현 돼있네)
 🥹헷갈려서 죽을 뻔

그리고 아까 나은님이 말하신 오류도 수정했어요!
***

## 📷 ScreenShot

https://github.com/SWCF-8TEAM/taskify/assets/72639353/6688fa75-fab1-4f1a-98b8-5c0134d13e89

---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
