### PR TITLE
💫 feat: 대시보드에 있는 + 버튼 누르면 할 일 모달 오픈, 카드 누르면 상세 모양 모달 오픈

### DIFF
--- a/api/columns/columns.types.ts
+++ b/api/columns/columns.types.ts
@@ -16,7 +16,7 @@ export interface CardImage {
 
 export interface GetColumnsProps {
   dashboardId?: number;
-  token?: string;
+  token?: string | null;
 }
 
 export interface PutColumnsProps {

--- a/components/Dashboard/Card/Card.tsx
+++ b/components/Dashboard/Card/Card.tsx
@@ -5,10 +5,23 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import { formatDate } from "@/utils/FormatDate";
 import styled from "styled-components";
 import { Card } from "@/api/cards/cards.types";
+import { useModal } from "@/hooks/useModal";
+import ModalWrapper from "@/components/Modal/ModalWrapper";
+import TaskModal from "@/components/Modal/TaskModal";
 
 const Card = ({ cardData }: { cardData: Card }) => {
+  const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
+
+  const handleCloseModal = () => {
+    closeModalFunc();
+  };
+
   return (
-    <Wrapper>
+    <Wrapper
+      onClick={() => {
+        openModalFunc();
+      }}
+    >
       {cardData.imageUrl && <CardImage $cardimage={cardData.imageUrl || null} />}
       <Title $imageurl={cardData.imageUrl}>{cardData.title}</Title>
       {cardData.tags[0] && (
@@ -34,6 +47,11 @@ const Card = ({ cardData }: { cardData: Card }) => {
           </NoProfileImageWrapper>
         )}
       </div>
+      {isModalOpen && (
+        <ModalWrapper>
+          <TaskModal />
+        </ModalWrapper>
+      )}
     </Wrapper>
   );
 };

--- a/components/Dashboard/Column/Column.tsx
+++ b/components/Dashboard/Column/Column.tsx
@@ -6,6 +6,9 @@ import Button from "@/components/common/Buttons/Button";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { getCardList } from "@/api/cards";
 import { Card as CardData } from "@/api/cards/cards.types";
+import TodoModal from "@/components/Modal/TodoModal";
+import { useModal } from "@/hooks/useModal";
+import ModalWrapper from "@/components/Modal/ModalWrapper";
 
 interface ColumnProps {
   columnId: number;
@@ -14,6 +17,11 @@ interface ColumnProps {
 
 const Column = ({ columnId, title }: ColumnProps) => {
   const [cards, setCards] = useState<CardData[]>([]);
+  const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
+
+  const handleCloseModal = () => {
+    closeModalFunc();
+  };
 
   useEffect(() => {
     const loadCardList = async () => {
@@ -21,8 +29,7 @@ const Column = ({ columnId, title }: ColumnProps) => {
         size: 10,
         cursorId: null,
         columnId,
-        token:
-          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjE2LCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNzQxODYxLCJpc3MiOiJzcC10YXNraWZ5In0.onJAVE-0l39MjS77mTbfnS6UMU5bWMkVgBKlA-rs03U",
+        token: localStorage.getItem("accessToken"),
       });
 
       if (res !== null) {
@@ -37,7 +44,17 @@ const Column = ({ columnId, title }: ColumnProps) => {
     <Wrapper>
       <ColumnHeader title={title} columnId={columnId} count={cards.length} />
       <Container>
-        <Button type="plus" disabled />
+        <Button
+          type="plus"
+          onClick={() => {
+            openModalFunc();
+          }}
+        />
+        {isModalOpen && (
+          <ModalWrapper>
+            <TodoModal type="create" />
+          </ModalWrapper>
+        )}
         {cards.map((card) => {
           return <Card key={card.id} cardData={card} />;
         })}

--- a/components/Dashboard/Column/Columns.tsx
+++ b/components/Dashboard/Column/Columns.tsx
@@ -16,13 +16,14 @@ const Columns = () => {
     const loadColumnsData = async () => {
       const res = await getColumns({
         dashboardId: 399,
-        token:
-          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjE2LCJ0ZWFtSWQiOiIxLTA4IiwiaWF0IjoxNzAzNzQxODYxLCJpc3MiOiJzcC10YXNraWZ5In0.onJAVE-0l39MjS77mTbfnS6UMU5bWMkVgBKlA-rs03U",
+        token: localStorage.getItem("accessToken"),
       });
       const columns = res?.data;
-      setColumns(() => {
-        return [...columns];
-      });
+      if (columns) {
+        setColumns(() => {
+          return [...columns];
+        });
+      }
     };
     loadColumnsData();
   }, []);


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
1. 제 기능쪽 토큰은 token: localStorage.getItem("accessToken”)로 다 수정했습니다.
2. 칼럼에 있는 + 버튼 누르면 할 일 생성 모달 나타나게 했습니다.
3. 카드를 클릭하면 카드의 상세 모달이 나타나게 했습니다.
***

## 📷 ScreenShot
---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
