### PR TITLE
💫 refactor: 대시보드 케밥, 모달 기능 수정

### DIFF
--- a/api/columns/columns.types.ts
+++ b/api/columns/columns.types.ts
@@ -15,8 +15,8 @@ export interface CardImage {
 }
 
 export interface GetColumnsProps {
-  dashboardId?: number;
-  token?: string | null;
+  dashboardId: number;
+  token: string | null;
 }
 
 export interface PutColumnsProps {

--- a/components/Dashboard/Column/ColumnHeader.tsx
+++ b/components/Dashboard/Column/ColumnHeader.tsx
@@ -3,7 +3,7 @@ import SettingIcon from "@/assets/icons/settings.svg";
 import CounterCard from "@/components/common/Chip/CounterCard";
 import styled from "styled-components";
 import KebabModal from "@/components/Modal/KebabModal";
-import { useState } from "react";
+import { useRef, useEffect, useState } from "react";
 
 interface ColumnHeaderProps {
   title: string;
@@ -13,10 +13,24 @@ interface ColumnHeaderProps {
 
 const ColumnHeader = ({ title, count }: ColumnHeaderProps) => {
   const [isClicked, setIsClicked] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
 
   const handleClick = () => {
     setIsClicked((prev) => !prev);
   };
+
+  useEffect(() => {
+    const handleOutsideClick = (event: Event) => {
+      if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+        setIsClicked(false);
+      }
+    };
+
+    document.addEventListener("click", handleOutsideClick);
+    return () => {
+      document.removeEventListener("click", handleOutsideClick);
+    };
+  }, []);
 
   return (
     <Wrapper>
@@ -25,7 +39,7 @@ const ColumnHeader = ({ title, count }: ColumnHeaderProps) => {
         <Title>{title}</Title>
         <CounterCard number={count} />
       </Content>
-      <Div>
+      <Div ref={modalRef}>
         <SettingIcon onClick={handleClick} style={{ cursor: "pointer" }} />
         {isClicked && <KebabModal />}
       </Div>

--- a/components/Modal/AlertModal.tsx
+++ b/components/Modal/AlertModal.tsx
@@ -21,7 +21,9 @@ const AlertModal = ({ type, onClick }: AlertProps) => {
       </Contents>
       <ButtonWrapper>
         {type === "delete" || type === "confirm" ? (
-          <ButtonSet type="modalSet">삭제</ButtonSet>
+          <ButtonSet type="modalSet" onClickLeft={onClick}>
+            삭제
+          </ButtonSet>
         ) : (
           <Button onClick={onClick} type="modalConfirm">
             확인

--- a/components/Modal/KebabModal.tsx
+++ b/components/Modal/KebabModal.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 import { DeviceSize } from "@/styles/DeviceSize";
-import { useEffect } from "react";
 import TodoModal from "@/components/Modal/TodoModal";
 import AlertModal from "@/components/Modal/AlertModal";
 import { Z_INDEX } from "@/styles/ZindexStyles";
@@ -8,39 +7,22 @@ import { useModal } from "@/hooks/useModal";
 import ModalWrapper from "@/components/Modal/ModalWrapper";
 
 const KebabModal = () => {
-  const { isModalOpen: isDeleteModalOpen, openModalFunc: openDeleteModalFunc, closeModalFunc: closeDeleteModalFunc } = useModal();
   const { isModalOpen: isEditModalOpen, openModalFunc: openEditModalFunc, closeModalFunc: closeEditModalFunc } = useModal();
-
-  useEffect(() => {
-    const handleKeyDown = (event: { key: string }) => {
-      if (event.key === "Escape") {
-        closeDeleteModalFunc();
-        closeEditModalFunc();
-      }
-    };
-
-    if (isDeleteModalOpen || isEditModalOpen) {
-      window.addEventListener("keydown", handleKeyDown);
-    }
-
-    return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [closeDeleteModalFunc, closeEditModalFunc]);
+  const { isModalOpen: isDeleteModalOpen, openModalFunc: openDeleteModalFunc, closeModalFunc: closeDeleteModalFunc } = useModal();
 
   return (
     <Wrapper>
       <KebabListWrapper>
         <KebabList onClick={openEditModalFunc}>수정하기</KebabList>
+        <KebabList onClick={openDeleteModalFunc}>삭제하기</KebabList>
         {isEditModalOpen && (
           <ModalWrapper>
-            <TodoModal type="edit" />
+            <TodoModal type="edit" onClick={closeEditModalFunc} />
           </ModalWrapper>
         )}
-        <KebabList onClick={openDeleteModalFunc}>삭제하기</KebabList>
         {isDeleteModalOpen && (
           <ModalWrapper>
-            <AlertModal type="delete" />
+            <AlertModal type="delete" onClick={closeDeleteModalFunc} />
           </ModalWrapper>
         )}
       </KebabListWrapper>

--- a/components/Modal/TodoModal.tsx
+++ b/components/Modal/TodoModal.tsx
@@ -7,9 +7,10 @@ import styled from "styled-components";
 
 interface CategoryProps {
   type: "create" | "edit";
+  onClick?: () => void;
 }
 
-const TodoModal = ({ type }: CategoryProps) => {
+const TodoModal = ({ type, onClick }: CategoryProps) => {
   return (
     <Wrapper>
       <TodoTitle>할 일 {type === "create" ? "생성" : "수정"}</TodoTitle>
@@ -22,7 +23,7 @@ const TodoModal = ({ type }: CategoryProps) => {
       <ModalInput $inputType="마감일" label="마감일" />
       <TagInput />
       <ButtonWrapper>
-        <ButtonSet type="modalSet">
+        <ButtonSet type="modalSet" onClickLeft={onClick}>
           {type === "create" && "생성"}
           {type === "edit" && "수정"}
         </ButtonSet>


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
1. 케밥 외 영역 클릭 시 케밥 닫히게 했습니다.
2. 수정하기 삭제하기 버튼 누르면 모달 뜨게 하고, 취소하기 버튼 누르면 모달 닫히게 했습니다.
3. 모달 닫히면 수정하기, 삭제하기 버튼도 같이 닫히게 수정했습니다.

근데요…..문제들이..
문제들…
1. 수정하기, 삭제하기 버튼 눌러서 모달이 띄워질 때 드롭다운 안닫히는 문제 -> 드롭다운 영역 안에 모달이 있기 때문에 모달이 띄워질 때 드롭다운만 닫을 수 없음(물론 둘을 분리한다면야 할 수 있겠지만…대공사). 하지만 모달이 닫힐 땐 같이 닫힘! 
2. 드롭다운 간의 상호작용..(다른 드롭다운이 클릭되면 열린 드롭다운 닫히는..) 전역변수로 이용해야하는데 구현해봤더니 수정하기 삭제하기 드롭다운은 모든 컬럼마다 있어서 만약 조타이 사용하면 모든 컬럼에서 열리는 문제…
***

## 📷 ScreenShot

https://github.com/SWCF-8TEAM/taskify/assets/72639353/b9f15540-6dc4-421b-8c82-fc0817028186



## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
