### PR TITLE
🛠️ fix: header 프로필 이미지 다르게 보이는 것 수정

### DIFF
--- a/components/Dashboard/Card/Card.tsx
+++ b/components/Dashboard/Card/Card.tsx
@@ -34,7 +34,7 @@ const Card = ({ cardData, columnId, columnTitle }: { cardData: Card; columnId: n
         {cardData.assignee && (
           <div style={{ position: "absolute", right: "2rem", bottom: "2rem" }}>
             {cardData.assignee.profileImageUrl ? (
-              <ProfileImage url={cardData.assignee.profileImageUrl} />
+              <ProfileImage $url={cardData.assignee.profileImageUrl} />
             ) : (
               <NoProfileImageWrapper>
                 <NoProfileImage id={cardData.assignee.id} nickname={cardData.assignee.nickname} />
@@ -180,13 +180,13 @@ const Date = styled.div`
   }
 `;
 
-const ProfileImage = styled.div<{ url: string }>`
+const ProfileImage = styled.div<{ $url: string }>`
   width: 2.7rem;
   height: 2.7rem;
 
   border-radius: 4.4rem;
 
-  background-image: url(${(props) => props.url});
+  background-image: url(${(props) => props.$url});
   background-size: cover;
 `;
 

--- a/components/Table/MemberList.tsx
+++ b/components/Table/MemberList.tsx
@@ -7,6 +7,7 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
+import NoProfileImage from "../common/NoProfileImage/ProfileImage";
 
 const PAGE_SIZE = 4; // 임의로 추가
 
@@ -62,7 +63,13 @@ const MembersList = () => {
       {members.map((member) => (
         <MemberItem key={member.id}>
           <MemberInfo>
-            <Profile src={member.profileImageUrl} alt={member.nickname} />
+            {member.profileImageUrl ? (
+              <Profile $url={member.profileImageUrl} />
+            ) : (
+              <NoProfileImageWrapper>
+                <NoProfileImage id={member.userId} nickname={member.nickname} />
+              </NoProfileImageWrapper>
+            )}
             <Name>{member.nickname}</Name>
           </MemberInfo>
           <Button type="delete" children="삭제" />
@@ -181,7 +188,7 @@ const MemberInfo = styled.div`
   flex-grow: 1;
 `;
 
-const Profile = styled.img`
+const Profile = styled.div<{ $url: string }>`
   width: 3.8rem;
   height: 3.8rem;
 
@@ -190,6 +197,8 @@ const Profile = styled.img`
   border-radius: 50%;
 
   object-fit: cover;
+  background-image: url(${(props) => props.$url});
+  background-size: cover;
 
   @media screen and (max-width: ${DeviceSize.mobile}) {
     width: 3.4rem;
@@ -198,7 +207,23 @@ const Profile = styled.img`
     margin-right: 0.8rem;
   }
 `;
+const NoProfileImageWrapper = styled.div`
+  width: 3.8rem;
 
+  line-height: 3.8rem;
+  font-size: 1.5rem;
+
+  margin-right: 1.2rem;
+
+  @media screen and (max-width: ${DeviceSize.mobile}) {
+    width: 3.4rem;
+
+    line-height: 3.4rem;
+    font-size: 1.3rem;
+
+    margin-right: 0.8rem;
+  }
+`;
 const Name = styled.div`
   color: var(--Black33);
   font-size: 1.6rem;

--- a/components/common/Nav/MemberListDropdown.tsx
+++ b/components/common/Nav/MemberListDropdown.tsx
@@ -9,10 +9,10 @@ const MemberListDropdown = ({ members }: { members: Member[] }) => {
       {members.map((member) => (
         <Item key={member.id}>
           {member.profileImageUrl ? (
-            <Profile src={member.profileImageUrl} alt={member.nickname} />
+            <Profile $url={member.profileImageUrl} />
           ) : (
             <NoProfileImageWrapper>
-              <NoProfileImage id={member.id} nickname={member.nickname} />
+              <NoProfileImage id={member.userId} nickname={member.nickname} />
             </NoProfileImageWrapper>
           )}
 
@@ -62,7 +62,7 @@ const Item = styled.div`
   }
 `;
 
-const Profile = styled.img`
+const Profile = styled.div<{ $url: string }>`
   width: 3rem;
   height: 3rem;
 
@@ -71,6 +71,8 @@ const Profile = styled.img`
   border-radius: 50%;
 
   object-fit: cover;
+  background-image: url(${(props) => props.$url});
+  background-size: cover;
 
   @media screen and (max-width: ${DeviceSize.mobile}) {
     width: 3.4rem;

--- a/components/common/Nav/MemberListDropdown.tsx
+++ b/components/common/Nav/MemberListDropdown.tsx
@@ -9,10 +9,10 @@ const MemberListDropdown = ({ members }: { members: Member[] }) => {
       {members.map((member) => (
         <Item key={member.id}>
           {member.profileImageUrl ? (
-            <Profile src={member.profileImageUrl} alt={member.nickname} />
+            <Profile $image={member.profileImageUrl} />
           ) : (
             <NoProfileImageWrapper>
-              <NoProfileImage id={member.id} nickname={member.nickname} />
+              <NoProfileImage id={member.userId} nickname={member.nickname} />
             </NoProfileImageWrapper>
           )}
 
@@ -62,7 +62,7 @@ const Item = styled.div`
   }
 `;
 
-const Profile = styled.img`
+const Profile = styled.div<{ $image: string }>`
   width: 3rem;
   height: 3rem;
 
@@ -71,6 +71,8 @@ const Profile = styled.img`
   border-radius: 50%;
 
   object-fit: cover;
+  background-image: url(${(props) => props.$image});
+  background-size: cover;
 
   @media screen and (max-width: ${DeviceSize.mobile}) {
     width: 3.4rem;

--- a/components/common/Nav/Profile.tsx
+++ b/components/common/Nav/Profile.tsx
@@ -53,7 +53,7 @@ const Profile = () => {
       {user && (
         <Wrapper onClick={toggleKebabMenu} ref={dropdownRef}>
           {user.profileImageUrl ? (
-            <ProfileIcon image={user.profileImageUrl} />
+            <ProfileIcon $image={user.profileImageUrl} />
           ) : (
             <NoProfileImageWrapper>
               <NoProfileImage id={user.id} nickname={user.nickname} isBorder={true} />
@@ -106,13 +106,13 @@ const Wrapper = styled.div`
   cursor: pointer;
 `;
 
-const ProfileIcon = styled.div<{ image: string }>`
+const ProfileIcon = styled.div<{ $image: string }>`
   width: 3.8rem;
   height: 3.8rem;
 
   border-radius: 100%;
 
-  background-image: url(${(props) => props.image});
+  background-image: url(${(props) => props.$image});
   background-size: cover;
   background-repeat: no-repeat;
 

--- a/components/common/Nav/ProfileImages.tsx
+++ b/components/common/Nav/ProfileImages.tsx
@@ -55,10 +55,10 @@ const ProfileImages = () => {
         <Contents>
           {members.slice(0, 4).map((member, index) =>
             member.profileImageUrl ? (
-              <ProfileImg key={member.id} $index={index} image={member.profileImageUrl} />
+              <ProfileImg key={member.id} $index={index} $image={member.profileImageUrl} />
             ) : (
               <NoProfileImageWrapper key={member.id} $index={index}>
-                <NoProfileImage id={member.id} nickname={member.nickname} isBorder={true} />
+                <NoProfileImage id={member.userId} nickname={member.nickname} isBorder={true} />
               </NoProfileImageWrapper>
             ),
           )}
@@ -107,7 +107,7 @@ const Contents = styled.div`
   }
 `;
 
-const ProfileImg = styled.div<{ $index: number; image: string }>`
+const ProfileImg = styled.div<{ $index: number; $image: string }>`
   width: 3.8rem;
   height: 3.8rem;
 
@@ -121,7 +121,7 @@ const ProfileImg = styled.div<{ $index: number; image: string }>`
   border-radius: 100%;
   border: 2px solid var(--White);
 
-  background-image: url(${(props) => props.image});
+  background-image: url(${(props) => props.$image});
   background-size: cover;
   background-repeat: no-repeat;
 

--- a/components/common/Nav/ProfileImages.tsx
+++ b/components/common/Nav/ProfileImages.tsx
@@ -58,7 +58,7 @@ const ProfileImages = () => {
               <ProfileImg key={member.id} $index={index} image={member.profileImageUrl} />
             ) : (
               <NoProfileImageWrapper key={member.id} $index={index}>
-                <NoProfileImage id={member.id} nickname={member.nickname} isBorder={true} />
+                <NoProfileImage id={member.userId} nickname={member.nickname} isBorder={true} />
               </NoProfileImageWrapper>
             ),
           )}


### PR DESCRIPTION
fix: 헤더,프로필 NoProfileImage같게 수정, refactor: image태그 대신 div이용

## 🥺 Issue Number
---
## 📝 Description
- [x] 헤더의 프로필 이미지 같도록 수정
- [x] 구성원 리스트에도 NoProfileImage 적용
- [x] image태그는 warning이 발생해서 div에 backgroud-image로 수정
***

## 📷 ScreenShot
--- 
<img width="325" alt="스크린샷 2024-01-02 오후 1 50 22" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/e7258c87-a446-4105-877e-fe2ed8652dc2">
<img width="428" alt="스크린샷 2024-01-02 오후 1 59 20" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/0d921460-3c45-4935-b7cb-661a77e4291f">

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
