### PR TITLE
💫 feat: 대시보드 삭제 기능 구현, 삭제완료시 리다이렉트

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -32,9 +32,9 @@ export const ENDPOINTS = {
   DASHBOARDS: {
     POST: `/dashboards`,
     GET_LIST: `/dashboards`,
-    GET: (dashboardid: string) => `/dashboards/${dashboardid}`,
-    PUT: (dashboardid: string) => `/dashboards/${dashboardid}`,
-    DELETE: (dashboardid: string) => `/dashboards/${dashboardid}`,
+    GET: (dashboardid: number) => `/dashboards/${dashboardid}`,
+    PUT: (dashboardid: number) => `/dashboards/${dashboardid}`,
+    DELETE: (dashboardid: number) => `/dashboards/${dashboardid}`,
     POST_INVITATION: (dashboardid: number) => `/dashboards/${dashboardid}/invitations`,
     GET_INVITATION: (dashboardid: number) => `/dashboards/${dashboardid}/invitations`,
     DELETE_INVITATION: (dashboardId: string, invitationId: string) => `/dashboards/${dashboardId}/invitations/${invitationId}`,

--- a/api/dashboards/dashboards.types.ts
+++ b/api/dashboards/dashboards.types.ts
@@ -22,8 +22,8 @@ export interface GetDashboardInvitationsData {
 }
 
 export interface DeleteDashboardProps {
-  dashboardId: string;
-  token: string;
+  dashboardId: number;
+  token: string | null;
 }
 
 export interface DeleteDashboardInvitationsProps {

--- a/api/dashboards/index.ts
+++ b/api/dashboards/index.ts
@@ -15,10 +15,7 @@ import {
 } from "@/api/dashboards/dashboards.types";
 import { Invitation } from "@/api/invitations/invitations.types";
 
-export const deleteDashboard = async ({
-  dashboardId = "193",
-  token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTMsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1NjYyOTgsImlzcyI6InNwLXRhc2tpZnkifQ.zNaGd4uESNMzrDDHokuybQNJs_CkFLY7SpYKgafPBl0",
-}: DeleteDashboardProps) => {
+export const deleteDashboard = async ({ dashboardId, token }: DeleteDashboardProps) => {
   try {
     const res = await instance.delete(ENDPOINTS.DASHBOARDS.DELETE(dashboardId), {
       headers: {

--- a/pages/dashboard/[boardid]/edit.tsx
+++ b/pages/dashboard/[boardid]/edit.tsx
@@ -1,3 +1,5 @@
+import AlertModal from "@/components/Modal/AlertModal";
+import ModalWrapper from "@/components/Modal/ModalWrapper";
 import EditDashboard from "@/components/Table/EditDashboard";
 import InvitationHistory from "@/components/Table/InvitationHistory";
 import MembersList from "@/components/Table/MemberList";
@@ -5,13 +7,28 @@ import BackButton from "@/components/common/Buttons/BackButton";
 import Button from "@/components/common/Buttons/Button";
 import DashboardNav from "@/components/common/Nav/DashboardNav";
 import SideMenu from "@/components/common/SideMenu/SideMenu";
+import { useModal } from "@/hooks/useModal";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useRouter } from "next/router";
 import styled from "styled-components";
+import { deleteDashboard } from "@/api/dashboards";
 
 const DashboardEditPage = () => {
   const router = useRouter();
   const { boardid } = router.query;
+  const token = localStorage.getItem("accessToken");
+
+  const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
+
+  const handleDeleteClick = () => {
+    openModalFunc();
+  };
+
+  const handleConfirmDelete = async () => {
+    await deleteDashboard({ dashboardId: boardid, token });
+    closeModalFunc();
+    router.push(`/mydashboard`);
+  };
 
   return (
     <Wrapper>
@@ -23,7 +40,14 @@ const DashboardEditPage = () => {
         <MembersList />
         <InvitationHistory />
         <StyledButton>
-          <Button type="deleteDashboard">대시보드 삭제하기</Button>
+          <Button type="deleteDashboard" onClick={handleDeleteClick}>
+            대시보드 삭제하기
+          </Button>
+          {isModalOpen && (
+            <ModalWrapper>
+              <AlertModal type="confirm" onCancel={closeModalFunc} onConfirm={handleConfirmDelete}></AlertModal>
+            </ModalWrapper>
+          )}
         </StyledButton>
       </Container>
     </Wrapper>


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description

- 대시보드 삭제 취소/삭제 기능
- 삭제 완료시 대시보드 목록에서 사라지고, mydashboard 페이지로 리다이렉트 됩니다

## 📷 ScreenShot
---
![dashboard-delete](https://github.com/SWCF-8TEAM/taskify/assets/144667455/d5c57924-4f93-4c55-bd87-8929aa0de638)


## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
