### PR TITLE
💫 feat: 404 페이지 구현

### DIFF
--- a/components/common/Nav/DashboardNav.tsx
+++ b/components/common/Nav/DashboardNav.tsx
@@ -10,8 +10,11 @@ const DashboardNav = () => {
   const [dashboard, setDashboard] = useState<Dashboard>();
 
   useEffect(() => {
-    if (!boardid) return;
     const loadDashboardData = async () => {
+      if (!boardid) {
+        router.push(`/404`);
+        return;
+      }
       const res = await getDashboard({ dashboardId: String(boardid), token: localStorage.getItem("accessToken") });
       if (res !== null) setDashboard(res);
     };

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,15 @@ const nextConfig = {
 
     return config;
   },
+  async redirects() {
+    return [
+      {
+        source: "/dashboard/:boardid/edit",
+        destination: "/404",
+        permanent: false,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/pages/404/index.tsx
+++ b/pages/404/index.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import styled from "styled-components";
+import MainLogo from "@/assets/icons/main-logo.svg";
+
+const NotFoundPage = () => {
+  return (
+    <Wrapper>
+      <Link href="/">
+        <MainLogo />
+      </Link>
+      <Text>
+        접근 권한이 없거나 존재하지 않는 페이지입니다.
+        <br />
+        다른 주소를 시도하거나 홈페이지로 돌아가세요.
+      </Text>
+    </Wrapper>
+  );
+};
+
+export default NotFoundPage;
+
+const Wrapper = styled.div`
+  height: 100vh;
+
+  padding-top: 30vh;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  background-color: var(--MainBG);
+`;
+
+const Text = styled.div`
+  line-height: 4rem;
+
+  font-size: 2rem;
+  text-align: center;
+`;

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -5,8 +5,20 @@ import InvitedDashboard from "@/components/Table/InvitedDashboard";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { styled } from "styled-components";
 import { Z_INDEX } from "@/styles/ZindexStyles";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 
 const MyDashboard = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+
+    if (!token) {
+      router.push("/404");
+    }
+  }, [router]);
+
   return (
     <>
       <MyDashboardNav />

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -5,11 +5,20 @@ import SettingNav from "@/components/common/Nav/SettingNav";
 import SettingSideMenu from "@/components/common/SideMenu/SettingSideMenu";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import styled from "styled-components";
 
 const Mypage = () => {
   const router = useRouter();
   const { tab } = router.query;
+
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+
+    if (!token) {
+      router.push("/404");
+    }
+  }, [router]);
 
   return (
     <Wrapper>


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- [x] 이상한 경로로 접근하면 무조건 404로 리다이렉트
로그아웃 상태일 때
- [x] /, /signin, /signup 페이지 외의 페이지로 접근 시 404로 리다이렉트
로그인 상태일 때
- [x] /dashboard/[boardid]에서 내가 속한 대시보드가 아닌 경로로 접근하면 404페이지
- [x] /dashboard/[boardid]/edit으로 접근 시 무조건 404로 리다이렉트(버튼으로만 접근 가능) -> 내가 대시보드 생성자여도 경로로 접근하면 오류나길래 우선 이렇게 구현….
***

## 📷 ScreenShot
### 로그아웃 상태

- mypage 접근

https://github.com/SWCF-8TEAM/taskify/assets/102296721/f7e28870-9cb2-44cb-bd79-d498c931fb18

- mydashboard 접근

https://github.com/SWCF-8TEAM/taskify/assets/102296721/ae54d0f0-4da9-426d-9154-8cfaaad9dbf8

- dashboard/[boardid], dashboard/[boardid]/edit 접근

https://github.com/SWCF-8TEAM/taskify/assets/102296721/cbffbef7-11d8-49db-8444-e8fec1af4845

### 로그인 상태

- 내가 속한 대시보드가 아닌 페이지로 접근

https://github.com/SWCF-8TEAM/taskify/assets/102296721/14020b61-f4a7-4df3-8c18-d5529a626068

- dashboard/[boardid]/edit 접근

https://github.com/SWCF-8TEAM/taskify/assets/102296721/56549905-9a7c-42c3-b5bc-9c1543c582b3


---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
