### PR TITLE
💫feat: 대시보드 이름 변경시 즉시 사이드메뉴와 헤더에 즉시 반영 (수정중..)

### DIFF
--- a/api/dashboards/dashboards.types.ts
+++ b/api/dashboards/dashboards.types.ts
@@ -59,8 +59,8 @@ export interface PostDashboardInvitationsProps {
 }
 
 export interface PutDashboardProps {
-  dashboardId: string;
-  token: string;
+  dashboardId: number;
+  token: string | null;
 }
 
 export interface PostDashboardProps {

--- a/api/dashboards/index.ts
+++ b/api/dashboards/index.ts
@@ -131,16 +131,13 @@ export const postDashboardInvitations = async ({ email, dashboardId, token }: Po
   }
 };
 
-export const putDashboard = async ({
-  dashboardId = "193",
-  token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTMsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1NjYyOTgsImlzcyI6InNwLXRhc2tpZnkifQ.zNaGd4uESNMzrDDHokuybQNJs_CkFLY7SpYKgafPBl0",
-}: PutDashboardProps): Promise<Dashboard | null> => {
+export const putDashboard = async ({ dashboardId, token, title, color }: PutDashboardProps): Promise<Dashboard | null> => {
   try {
     const res = await instance.put(
       ENDPOINTS.DASHBOARDS.PUT(dashboardId),
       {
-        title: "api 만든 사람 완전히 망해라",
-        color: "#000000",
+        title,
+        color,
       },
       {
         headers: {

--- a/components/Table/EditDashboard.tsx
+++ b/components/Table/EditDashboard.tsx
@@ -6,26 +6,41 @@ import ToastModal from "@/components/Modal/ToastModal";
 import { toast } from "react-toastify";
 import { useRouter } from "next/router";
 import { getDashboard } from "@/api/dashboards";
+import { putDashboard } from "@/api/dashboards";
 import { Dashboard } from "@/api/dashboards/dashboards.types";
+import { useAtom } from "jotai";
+import { dashBoardNameAtom } from "@/states/atoms";
 
 const EditDashboard = () => {
   const [toastVisible, setToastVisible] = useState(false);
+  const [currentDashboardName, setCurrentDashboardName] = useAtom(dashBoardNameAtom);
   const [dashboard, setDashboard] = useState<Dashboard>();
   const router = useRouter();
   const { boardid } = router.query;
 
-  const handleClick = () => {
+  const handleClick = async () => {
     toast("변경이 완료되었습니다.");
     setToastVisible((prev) => !prev);
+
+    const changeDashboardName = await putDashboard({
+      dashboardId: Number(boardid),
+      newName: currentDashboardName,
+      token: localStorage.getItem("accessToken"),
+    });
+    setDashboard((prevDashboard) => ({
+      ...prevDashboard,
+      title: currentDashboardName,
+    }));
   };
 
   const loadDashboardData = async () => {
     const res = await getDashboard({ dashboardId: Number(boardid), token: localStorage.getItem("accessToken") });
     if (res) setDashboard(res);
   };
+
   useEffect(() => {
     loadDashboardData();
-  }, [boardid]);
+  }, [setDashboard, boardid]);
 
   return (
     <Wrapper>
@@ -35,7 +50,7 @@ const EditDashboard = () => {
       </Header>
       <Form>
         <Label>대시보드 이름</Label>
-        <Input placeholder="변경할 이름을 입력해 주세요." />
+        <Input value={currentDashboardName} onChange={(e) => setCurrentDashboardName(e.target.value)} placeholder="변경할 이름을 입력해 주세요." />
       </Form>
       <ButtonWrapper>
         <Button onClick={handleClick}> 변경</Button>

--- a/components/Table/EditDashboard.tsx
+++ b/components/Table/EditDashboard.tsx
@@ -9,11 +9,11 @@ import { getDashboard } from "@/api/dashboards";
 import { putDashboard } from "@/api/dashboards";
 import { Dashboard } from "@/api/dashboards/dashboards.types";
 import { useAtom } from "jotai";
-import { dashBoardNameAtom } from "@/states/atoms";
+import { dashboardNamesAtom } from "@/states/atoms";
 
 const EditDashboard = () => {
   const [toastVisible, setToastVisible] = useState(false);
-  const [currentDashboardName, setCurrentDashboardName] = useAtom(dashBoardNameAtom);
+  const [currentDashboardName, setCurrentDashboardName] = useAtom(dashboardNamesAtom);
   const [dashboard, setDashboard] = useState<Dashboard>();
   const router = useRouter();
   const { boardid } = router.query;
@@ -24,13 +24,10 @@ const EditDashboard = () => {
 
     const changeDashboardName = await putDashboard({
       dashboardId: Number(boardid),
-      newName: currentDashboardName,
+      title: currentDashboardName,
       token: localStorage.getItem("accessToken"),
     });
-    setDashboard((prevDashboard) => ({
-      ...prevDashboard,
-      title: currentDashboardName,
-    }));
+    setDashboard(changeDashboardName);
   };
 
   const loadDashboardData = async () => {
@@ -40,7 +37,7 @@ const EditDashboard = () => {
 
   useEffect(() => {
     loadDashboardData();
-  }, [setDashboard, boardid]);
+  }, [setDashboard, boardid, setCurrentDashboardName]);
 
   return (
     <Wrapper>

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -19,6 +19,7 @@ import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useInfiniteScrollNavigator } from "@/hooks/useInfiniteScrollNavigator";
 import { FaArrowUpWideShort } from "react-icons/fa6";
 import { useRouter } from "next/router";
+import { dashboardNamesAtom } from "@/states/atoms";
 
 interface DashboardProps {
   boardId: number;
@@ -35,6 +36,7 @@ const Dashboard = ({ color, title, createdByMe, boardId }: DashboardProps) => {
   const router = useRouter();
   const { boardid } = router.query;
   const isActive = boardId === Number(boardid);
+  const [currentDashboardName, setCurrentDashboardName] = useAtom(dashboardNamesAtom);
 
   return (
     <Container href={`/dashboard/${boardId}`} $isActive={isActive}>

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -15,7 +15,7 @@ export const totalColumnsAtom = atom(0);
 
 export const dashboardColorAtom = atom<string>(`${DASHBOARD_COLOR[0]}`);
 
-export const dashBoardNameAtom = atom<string>("");
+export const dashboardNamesAtom = atom<{ [key: number]: string }>({});
 
 export const cardsAtom = atom<{ [columnId: number]: Card[] }>({});
 

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -3,6 +3,7 @@ import { Invitation } from "@/api/invitations/invitations.types";
 import { DASHBOARD_COLOR } from "@/constants/ColorConstant";
 import { Columns } from "@/api/columns/columns.types";
 import { Card } from "@/api/cards/cards.types";
+// import { Dashboard } from "@/api/dashboards/dashboards.types";
 
 // 현재 활성화된 드롭다운의 식별자를 저장하는 아톰
 export const activeDropdownAtom = atom<string | null>(null);
@@ -13,6 +14,8 @@ export const columnsAtom = atom<Columns[]>([]);
 export const totalColumnsAtom = atom(0);
 
 export const dashboardColorAtom = atom<string>(`${DASHBOARD_COLOR[0]}`);
+
+export const dashBoardNameAtom = atom<string>("");
 
 export const cardsAtom = atom<{ [columnId: number]: Card[] }>({});
 


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- 대시보드 이름 변경시 EditDashboard 테이블에서 즉시 반영됩니다
- 사이드메뉴, 헤더는 새로고침시 반영됩니다 (POST요청을 한 것이 새로고침시 반영이 되는 것 같고 변경한 대시보드의 이름을 전역변수로 관리해서 즉시 반영되도록 변경하고싶은데 잘 안됩니다 ㅜㅜ 사이드메뉴에 atom과 이것저것 추가했는데 잘 안됐습니다,,
- 대시보드 이름을 변경하고 새로고침하면 로컬스토리지 이슈가 발생합니다 (왜인지 모를 ㅜㅜ)
- 대시보드 이름을 변경하는 인풋 PlaceHolder가 망가졌는데........ 어쩌다 이렇게 됐는지 원인을 모르겠씁니다 ㅜㅜ...  jotai사용하면서 망가진것 같습니다 ,,, 

나는야 버그생성기
 
***

## 📷 ScreenShot
---
![2024-01-03 10;43;07](https://github.com/SWCF-8TEAM/taskify/assets/144667455/a06e68a8-7a5e-452a-a21e-d8203f4a0ead)



## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
