### PR TITLE
💫  feat :  태스크 수정 후 바로 반영

### DIFF
--- a/api/cards/cards.types.ts
+++ b/api/cards/cards.types.ts
@@ -5,7 +5,7 @@ export interface Card {
   tags: string[];
   dueDate: string;
   assignee: {
-    profileImageUrl?: string;
+    profileImageUrl?: string | null;
     nickname: string;
     id: number;
   };
@@ -36,14 +36,14 @@ export interface GetCardListProps {
 }
 
 export interface CardProps {
-  assigneeUserId?: number;
+  assigneeUserId?: number | null;
   dashboardId: number;
   columnId: number;
   title: string;
   description: string;
-  dueDate?: string;
+  dueDate?: string | null;
   tags: string[];
-  imageUrl?: string;
+  imageUrl?: string | null;
   token: string | null;
 }
 

--- a/components/Modal/AddTaskModal.tsx
+++ b/components/Modal/AddTaskModal.tsx
@@ -59,11 +59,16 @@ const AddTaskModal = ({ closeModalFunc, columnId }: AddTaskModalProps) => {
       });
     }
 
-    setDueDate(""); //atom전역변수 초기화
+    deleteAtomData();
+    closeModalFunc();
+  };
+
+  //atom전역변수 초기화
+  const deleteAtomData = () => {
+    setDueDate("");
     setAssigneeUserId(null);
     setCardImage(null);
     setTags([]);
-    closeModalFunc();
   };
 
   const handleSelectMember = (userId: number) => setAssigneeUserId(userId);
@@ -84,7 +89,15 @@ const AddTaskModal = ({ closeModalFunc, columnId }: AddTaskModalProps) => {
       <TagInput />
       <ImageUploadInput type="modal" />
       <ButtonWrapper>
-        <ButtonSet type="modalSet" onClickLeft={closeModalFunc} onClickRight={handleSubmit} isRightDisabled={isSubmitDisable()}>
+        <ButtonSet
+          type="modalSet"
+          onClickLeft={() => {
+            closeModalFunc();
+            deleteAtomData();
+          }}
+          onClickRight={handleSubmit}
+          isRightDisabled={isSubmitDisable()}
+        >
           생성
         </ButtonSet>
       </ButtonWrapper>

--- a/components/Modal/EditTaskModal.tsx
+++ b/components/Modal/EditTaskModal.tsx
@@ -29,6 +29,7 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
   const [assigneeUserId, setAssigneeUserId] = useAtom(cardAssigneeIdAtom);
   const [updatedCard, setUpdatedCard] = useAtom(cardAtom); //바로 업데이트를 위한 조타이
   const [isCardUpdated, setIsCardUpdated] = useAtom(isCardUpdatedAtom);
+  const [isImageDeleteClick, setIsImageDeleteClick] = useState(false);
   const [token, setToken] = useState<string | null>(null);
   const router = useRouter();
   const { boardid } = router.query;
@@ -69,7 +70,7 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
         imageUrl = cardImageRes.imageUrl;
       }
     } else {
-      imageUrl = null;
+       if(isImageDeleteClick)imageUrl=null;
     }
     const updatedCardData = {
       cardId: cardData.id,
@@ -137,7 +138,7 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
           <ModalInput $inputType="설명" label="설명" value={cardData.description} onChange={handleDescriptionChange} />
           <ModalInput label="마감일" $inputType="마감일" value={cardData.dueDate} />
           <TagInput initialTags={cardData.tags} />
-          <ImageUploadInput type="modal" initialImageUrl={cardData.imageUrl} />
+          <ImageUploadInput type="modal" initialImageUrl={cardData.imageUrl} handleDeleteClick = {setIsImageDeleteClick}/>
           <ButtonWrapper>
             <ButtonSet
               type="modalSet"

--- a/components/Modal/EditTaskModal.tsx
+++ b/components/Modal/EditTaskModal.tsx
@@ -9,7 +9,7 @@ import ButtonSet from "@/components/common/Buttons/ButtonSet";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
 import { useRouter } from "next/router";
-import { cardAssigneeIdAtom, cardImageAtom, cardsAtom, dueDateAtom, tagAtom } from "@/states/atoms";
+import { cardAssigneeIdAtom, cardAtom, cardImageAtom, cardsAtom, dueDateAtom, isCardUpdatedAtom, tagAtom } from "@/states/atoms";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import ModalInput from "./ModalInput/ModalInput";
@@ -27,6 +27,8 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
   const [dueDate, setDueDate] = useAtom(dueDateAtom);
   const [cardImage, setCardImage] = useAtom(cardImageAtom);
   const [assigneeUserId, setAssigneeUserId] = useAtom(cardAssigneeIdAtom);
+  const [updatedCard, setUpdatedCard] = useAtom(cardAtom); //바로 업데이트를 위한 조타이
+  const [isCardUpdated, setIsCardUpdated] = useAtom(isCardUpdatedAtom);
   const [token, setToken] = useState<string | null>(null);
   const router = useRouter();
   const { boardid } = router.query;
@@ -85,6 +87,9 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
 
     if (updatedCard) {
       console.log("Card updated successfully:", updatedCard);
+      setUpdatedCard({ ...updatedCard });
+      setIsCardUpdated(true);
+
       if (onEdit) onEdit();
     } else {
       console.error("Failed to update card");
@@ -108,7 +113,7 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
       if (data) {
         setCardData(data);
         setDueDate(data.dueDate);
-        setAssigneeUserId(data.assignee.id);
+        if (data.assignee) setAssigneeUserId(data.assignee.id);
         setTags(data.tags);
       }
     };
@@ -122,7 +127,11 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
           <TodoTitle>할 일 수정</TodoTitle>
           <DropdownWrapper>
             <StateDropdown dashboardId={cardData.dashboardId} defaultColumnId={cardData.columnId} onColumnSelect={handleColumnChange} />
-            <ContactDropdown onSelectMember={handleSelectMember} dashboardId={cardData.dashboardId} assigneeNickname={cardData.assignee.nickname} />
+            {cardData.assignee ? (
+              <ContactDropdown onSelectMember={handleSelectMember} dashboardId={cardData.dashboardId} assigneeNickname={cardData.assignee.nickname} />
+            ) : (
+              <ContactDropdown onSelectMember={handleSelectMember} dashboardId={cardData.dashboardId} />
+            )}
           </DropdownWrapper>
           <ModalInput label="제목" $inputType="제목" value={cardData.title} onChange={handleTitleChange} />
           <ModalInput $inputType="설명" label="설명" value={cardData.description} onChange={handleDescriptionChange} />

--- a/components/Modal/EditTaskModal.tsx
+++ b/components/Modal/EditTaskModal.tsx
@@ -1,6 +1,6 @@
 import { getCard, putCard } from "@/api/cards";
 import { postCardImage } from "@/api/columns";
-import { Card } from "@/api/cards/cards.types";
+import { Card, CardProps, PutCardProps } from "@/api/cards/cards.types";
 import ContactDropdown from "@/components/Modal/ModalInput/ContactDropdown";
 import ImageUploadInput from "@/components/Modal/ModalInput/ImageUploadInput";
 import StateDropdown from "@/components/Modal/ModalInput/StateDropdown";
@@ -27,28 +27,9 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
   const [dueDate, setDueDate] = useAtom(dueDateAtom);
   const [cardImage, setCardImage] = useAtom(cardImageAtom);
   const [assigneeUserId, setAssigneeUserId] = useAtom(cardAssigneeIdAtom);
-  const token = localStorage.getItem("accessToken");
+  const [token, setToken] = useState<string | null>(null);
   const router = useRouter();
   const { boardid } = router.query;
-  const dashboardId = Number(boardid);
-
-  useEffect(() => {
-    const fetchCardData = async () => {
-      const data = await getCard({ cardId, token });
-      if (data) {
-        setCardData(data);
-        setDueDate(data.dueDate);
-        setAssigneeUserId(data.assignee.id);
-        setTags(data.tags);
-      }
-    };
-
-    fetchCardData();
-  }, [cardId, token, setAssigneeUserId, setTags]);
-
-  if (!cardData) {
-    return <div>Loading...</div>;
-  }
 
   const handleColumnChange = (newColumnId: number) => {
     if (cardData) {
@@ -64,28 +45,19 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
   };
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setCardData({ ...cardData, title: e.target.value });
+    if (cardData) setCardData({ ...cardData, title: e.target.value });
   };
 
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setCardData({ ...cardData, description: e.target.value });
-  };
-
-  const handleDueDateChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const newDueDate = e.target.value;
-    setCardData({ ...cardData, dueDate: newDueDate });
-    setDueDate(newDueDate);
-  };
-
-  const handleTagsChange = (newTags: string[]) => {
-    setTags(newTags);
+    if (cardData) setCardData({ ...cardData, description: e.target.value });
   };
 
   const handleSubmit = async () => {
     if (!cardData) return;
 
-    let imageUrl = cardData.imageUrl;
+    let newDuedate = dueDate == "" ? null : dueDate;
 
+    let imageUrl: string | null = cardData.imageUrl;
     if (cardImage && cardImage instanceof File) {
       const formData = new FormData();
       formData.append("image", cardImage);
@@ -94,21 +66,21 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
       if (cardImageRes) {
         imageUrl = cardImageRes.imageUrl;
       }
+    } else {
+      imageUrl = null;
     }
-
     const updatedCardData = {
       cardId: cardData.id,
       dashboardId: cardData.dashboardId,
       columnId: cardData.columnId,
       title: cardData.title,
       description: cardData.description,
-      dueDate,
+      dueDate: newDuedate,
       tags,
-      ...(assigneeUserId !== null && { assigneeUserId }),
+      assigneeUserId,
       imageUrl,
       token,
     };
-
     const updatedCard = await putCard(updatedCardData);
 
     if (updatedCard) {
@@ -117,31 +89,62 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
     } else {
       console.error("Failed to update card");
     }
+    deleteAtomData();
   };
 
+  //atom전역변수 초기화
+  const deleteAtomData = () => {
+    setDueDate("");
+    setAssigneeUserId(null);
+    setCardImage(null);
+    setTags([]);
+  };
+
+  useEffect(() => {
+    setToken(localStorage.getItem("accessToken"));
+
+    const fetchCardData = async () => {
+      const data = await getCard({ cardId, token });
+      if (data) {
+        setCardData(data);
+        setDueDate(data.dueDate);
+        setAssigneeUserId(data.assignee.id);
+        setTags(data.tags);
+      }
+    };
+
+    if (token) fetchCardData();
+  }, [token]);
   return (
-    <Wrapper>
-      <TodoTitle>할 일 수정</TodoTitle>
-      <DropdownWrapper>
-        <StateDropdown dashboardId={cardData.dashboardId} defaultColumnId={cardData.columnId} onColumnSelect={handleColumnChange} />
-        <ContactDropdown
-          onSelectMember={handleSelectMember}
-          dashboardId={cardData.dashboardId}
-          assigneeProfileImageUrl={cardData.assignee.profileImageUrl}
-          assigneeNickname={cardData.assignee.nickname}
-        />
-      </DropdownWrapper>
-      <ModalInput label="제목" $inputType="제목" value={cardData.title} onChange={handleTitleChange} />
-      <ModalInput $inputType="설명" label="설명" value={cardData.description} onChange={handleDescriptionChange} />
-      <ModalInput label="마감일" $inputType="마감일" value={cardData.dueDate} onChange={handleDueDateChange} />
-      <TagInput initialTags={cardData.tags} onTagsChange={handleTagsChange} />
-      <ImageUploadInput type="modal" initialImageUrl={cardData.imageUrl} />
-      <ButtonWrapper>
-        <ButtonSet type="modalSet" onClickLeft={onCancel} onClickRight={handleSubmit} isRightDisabled={!cardData.title || !cardData.description}>
-          수정
-        </ButtonSet>
-      </ButtonWrapper>
-    </Wrapper>
+    <>
+      {cardData && (
+        <Wrapper>
+          <TodoTitle>할 일 수정</TodoTitle>
+          <DropdownWrapper>
+            <StateDropdown dashboardId={cardData.dashboardId} defaultColumnId={cardData.columnId} onColumnSelect={handleColumnChange} />
+            <ContactDropdown onSelectMember={handleSelectMember} dashboardId={cardData.dashboardId} assigneeNickname={cardData.assignee.nickname} />
+          </DropdownWrapper>
+          <ModalInput label="제목" $inputType="제목" value={cardData.title} onChange={handleTitleChange} />
+          <ModalInput $inputType="설명" label="설명" value={cardData.description} onChange={handleDescriptionChange} />
+          <ModalInput label="마감일" $inputType="마감일" value={cardData.dueDate} />
+          <TagInput initialTags={cardData.tags} />
+          <ImageUploadInput type="modal" initialImageUrl={cardData.imageUrl} />
+          <ButtonWrapper>
+            <ButtonSet
+              type="modalSet"
+              onClickLeft={() => {
+                onCancel();
+                deleteAtomData();
+              }}
+              onClickRight={handleSubmit}
+              isRightDisabled={!cardData.title || !cardData.description}
+            >
+              수정
+            </ButtonSet>
+          </ButtonWrapper>
+        </Wrapper>
+      )}
+    </>
   );
 };
 

--- a/components/Modal/EditTaskModal.tsx
+++ b/components/Modal/EditTaskModal.tsx
@@ -30,7 +30,7 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
   const [assigneeUserId, setAssigneeUserId] = useAtom(cardAssigneeIdAtom);
   const [updatedCard, setUpdatedCard] = useAtom(cardAtom); //바로 업데이트를 위한 조타이
   const [isCardUpdated, setIsCardUpdated] = useAtom(isCardUpdatedAtom);
-  const [firstColumnId, setFirstColumnId] = useState<number>(0);
+
   const [isImageDeleteClick, setIsImageDeleteClick] = useState(false);
   const [token, setToken] = useState<string | null>(null);
   const router = useRouter();
@@ -91,19 +91,6 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
       setUpdatedCard({ ...updatedCard });
       setIsCardUpdated(true);
       if (onEdit) onEdit();
-      //status를 다른 칼럼으로 옮겼을 시 즉시 반영
-      if (firstColumnId !== updatedCard.columnId) {
-        setCards((prev) => {
-          //바뀐 컬럼에 우선 추가
-
-          const updatedCardList = [updatedCard, ...cards[updatedCard.columnId]];
-          return { ...prev, [updatedCard.columnId]: updatedCardList };
-        });
-        setCards((prev) => {
-          const updatedCardList = [...prev[firstColumnId].filter((v) => v.id !== updatedCard.id)];
-          return { ...prev, [firstColumnId]: updatedCardList };
-        });
-      }
     } else {
       console.error("Failed to update card");
     }
@@ -128,7 +115,6 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
         setDueDate(data.dueDate);
         if (data.assignee) setAssigneeUserId(data.assignee.id);
         setTags(data.tags);
-        setFirstColumnId(data.columnId);
       }
     };
 

--- a/components/Modal/ModalInput/ContactDropdown.tsx
+++ b/components/Modal/ModalInput/ContactDropdown.tsx
@@ -7,15 +7,16 @@ import { useAtom } from "jotai";
 import { cardAssigneeIdAtom } from "@/states/atoms";
 import { Member } from "@/api/members/members.types";
 import { getMembers } from "@/api/members";
+import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
+import { DeviceSize } from "@/styles/DeviceSize";
 
 interface ContactDropdownProps {
   dashboardId: number;
   assigneeNickname?: string | null;
-  assigneeProfileImageUrl?: string | null;
   onSelectMember?: (userId: number) => void;
 }
 
-const ContactDropdown = ({ dashboardId, assigneeNickname, assigneeProfileImageUrl, onSelectMember }: ContactDropdownProps) => {
+const ContactDropdown = ({ dashboardId, assigneeNickname, onSelectMember }: ContactDropdownProps) => {
   const [membersData, setMembersData] = useState<Member[]>([]);
   const [filter, setFilter] = useState("");
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
@@ -82,7 +83,12 @@ const ContactDropdown = ({ dashboardId, assigneeNickname, assigneeProfileImageUr
       <Text>담당자</Text>
       <Container>
         <InputContainer>
-          {selectedMember && <SelectProfileIcon src={selectedMember.profileImageUrl} alt="Profile" />}
+          {selectedMember && selectedMember.profileImageUrl && <SelectProfileIcon src={selectedMember.profileImageUrl} alt="Profile" />}
+          {selectedMember && !selectedMember.profileImageUrl && (
+            <SelectedNoProfileImage>
+              <NoProfileImage id={selectedMember.userId} nickname={selectedMember.nickname} />
+            </SelectedNoProfileImage>
+          )}
           <Input
             type="text"
             value={filter}
@@ -99,7 +105,13 @@ const ContactDropdown = ({ dashboardId, assigneeNickname, assigneeProfileImageUr
           <List>
             {filteredMembers.map((membersData) => (
               <ListItem key={membersData.id} onClick={() => handleSelect(membersData)}>
-                <ProfileIcon src={membersData.profileImageUrl} alt="Profile" />
+                {membersData.profileImageUrl ? (
+                  <ProfileIcon src={membersData.profileImageUrl} alt="Profile" />
+                ) : (
+                  <NoProfileImageWrapper>
+                    <NoProfileImage id={membersData.userId} nickname={membersData.nickname} />
+                  </NoProfileImageWrapper>
+                )}
                 {membersData.nickname}
                 <CheckIconStyled />
               </ListItem>
@@ -154,6 +166,18 @@ const SelectProfileIcon = styled.img`
 
   transform: translateY(-50%);
   object-fit: cover;
+`;
+const SelectedNoProfileImage = styled.div`
+  width: 2.4rem;
+  line-height: 2.4rem;
+
+  position: absolute;
+  left: 1.6rem;
+  top: 50%;
+
+  border-radius: 50%;
+
+  transform: translateY(-50%);
 `;
 
 const Input = styled.input`
@@ -226,6 +250,15 @@ const ProfileIcon = styled.img`
   border-radius: 50%;
 
   object-fit: cover;
+`;
+
+const NoProfileImageWrapper = styled.div`
+  width: 2.4rem;
+
+  margin-right: 1rem;
+
+  line-height: 2.4rem;
+  font-size: 1.3rem;
 `;
 
 const CheckIconStyled = styled(CheckIcon)`

--- a/components/Modal/ModalInput/ImageUploadInput.tsx
+++ b/components/Modal/ModalInput/ImageUploadInput.tsx
@@ -3,15 +3,16 @@ import EditIcon from "@/assets/icons/edit.svg";
 import { cardImageAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
 import styled, { css } from "styled-components";
 
 interface ImageUploadInputProps {
   type: "modal" | "account";
   initialImageUrl?: string;
+  handleDeleteClick?: Dispatch<SetStateAction<boolean>>;
 }
 
-const ImageUploadInput = ({ type, className, initialImageUrl }: ImageUploadInputProps & { className?: string }) => {
+const ImageUploadInput = ({ type, className, initialImageUrl, handleDeleteClick }: ImageUploadInputProps & { className?: string }) => {
   const [selectedImage, setSelectedImage] = useAtom(cardImageAtom);
   const [previewUrl, setPreviewUrl] = useState<string | null>(initialImageUrl ?? null);
 
@@ -42,6 +43,7 @@ const ImageUploadInput = ({ type, className, initialImageUrl }: ImageUploadInput
           onClick={() => {
             setPreviewUrl(null);
             setSelectedImage(null);
+            if (handleDeleteClick) handleDeleteClick(true);
           }}
         >
           삭제

--- a/components/Modal/ModalInput/StateDropdown.tsx
+++ b/components/Modal/ModalInput/StateDropdown.tsx
@@ -22,6 +22,8 @@ const StateDropdown = ({ dashboardId, defaultColumnId, onColumnSelect }: StateDr
   const token = localStorage.getItem("accessToken");
 
   useEffect(() => {
+    //처음엔 드롭다운 무조건 닫혀있는 상태
+    setIsOpen(false);
     const fetchData = async () => {
       const data = await getColumns({ dashboardId, token });
       if (data && data.result === "SUCCESS") {
@@ -29,6 +31,7 @@ const StateDropdown = ({ dashboardId, defaultColumnId, onColumnSelect }: StateDr
         const defaultColumn = data.data.find((column) => column.id === defaultColumnId);
         if (defaultColumn) {
           setStatus(defaultColumn.title);
+          setSelectedId(defaultColumnId);
         }
       }
     };
@@ -44,6 +47,7 @@ const StateDropdown = ({ dashboardId, defaultColumnId, onColumnSelect }: StateDr
     setSelectedId(columnId);
     if (onColumnSelect) {
       onColumnSelect(columnId);
+      setIsOpen(false); //선택하면 드롭다운 닫아줌
     }
   };
 

--- a/components/Modal/ModalInput/TagInput.tsx
+++ b/components/Modal/ModalInput/TagInput.tsx
@@ -2,7 +2,7 @@ import Tag from "@/components/common/Chip/Tag";
 import { tagAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 import styled from "styled-components";
 
 interface TagsProps {
@@ -26,21 +26,12 @@ const Tags = ({ handleOnClick, tagValue }: TagsProps) => {
 
 interface TagInputProps {
   initialTags?: string[]; // 여기에 initialTags prop의 타입을 추가
-  onTagsChange?: (tags: string[]) => void;
 }
 
-const TagInput = ({ initialTags = [], onTagsChange }: TagInputProps) => {
+const TagInput = ({ initialTags = [] }: TagInputProps) => {
   const [inputValue, setInputValue] = useState("");
-  const [tagValue, setTagValue] = useState<string[]>(initialTags);
+  const [tagValue, setTagValue] = useAtom(tagAtom);
 
-  const updateTags = (newTags: string[]) => {
-    setTagValue(newTags);
-    if (onTagsChange) {
-      onTagsChange(newTags);
-    }
-  };
-
-  const [tag, setTag] = useAtom(tagAtom);
   const handleInputChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setInputValue(e.target.value);
   };
@@ -51,8 +42,6 @@ const TagInput = ({ initialTags = [], onTagsChange }: TagInputProps) => {
 
     const newTagValue = tagValue.filter((v) => v !== tagText);
     setTagValue(newTagValue);
-    updateTags(newTagValue);
-    setTag(newTagValue);
   };
 
   const handlePressEnter = (event: React.KeyboardEvent) => {
@@ -61,12 +50,13 @@ const TagInput = ({ initialTags = [], onTagsChange }: TagInputProps) => {
     if (!inputValue) return;
     if (tagValue.filter((v) => v == inputValue).length === 0) {
       setTagValue((prev) => [...prev, inputValue]);
-      setTag(tagValue);
     }
-    setInputValue(() => "");
-    updateTags([...tagValue, inputValue]);
     setInputValue("");
   };
+
+  useEffect(() => {
+    setTagValue(initialTags);
+  }, []);
 
   return (
     <InputBox>

--- a/components/Modal/TaskModal/TaskModal.tsx
+++ b/components/Modal/TaskModal/TaskModal.tsx
@@ -59,7 +59,6 @@ const TaskModal: React.FC<{ cardData: Card; columnId: number; closeModalFunc: ()
     closeModalFunc();
   };
 
-  const handleConfirmEdit = async () => {};
   return (
     <>
       <Wrapper ref={scrollContainerRef}>

--- a/components/Modal/TaskModal/TaskModal.tsx
+++ b/components/Modal/TaskModal/TaskModal.tsx
@@ -11,7 +11,7 @@ import ColumnName from "@/components/common/Chip/ColumnName";
 import Tag from "@/components/common/Chip/Tag";
 import { useInfiniteScrollNavigator } from "@/hooks/useInfiniteScrollNavigator";
 import { useModal } from "@/hooks/useModal";
-import { cardAtom, cardsAtom, cardsTotalCountAtom, commentScrollAtom, isCardUpdatedAtom } from "@/states/atoms";
+import { cardAtom, cardsAtom, cardsTotalCountAtom, commentScrollAtom, isCardUpdatedAtom, statusAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
 import React, { useEffect, useRef, useState } from "react";
@@ -28,6 +28,8 @@ const TaskModal: React.FC<{ cardData: Card; columnId: number; closeModalFunc: ()
   const { startRef, endRef, handleScrollNavClick, isScrollingUp } = useInfiniteScrollNavigator(scrollContainerRef);
   const [cards, setCards] = useAtom(cardsAtom);
   const [card, setCard] = useAtom(cardAtom);
+  const [updatedColumnTitle] = useAtom(statusAtom);
+  const [columnTitleData, setColumnTitle] = useState(columnTitle);
   const [isCardUpdated, setIsCardUpdated] = useAtom(isCardUpdatedAtom);
   const [isScrollActive, setIsScrollActive] = useAtom(commentScrollAtom);
   const [, setCardsTotalCount] = useAtom(cardsTotalCountAtom);
@@ -63,6 +65,7 @@ const TaskModal: React.FC<{ cardData: Card; columnId: number; closeModalFunc: ()
 
   useEffect(() => {
     if (!isCardUpdated) setCard(cardData);
+    else setColumnTitle(updatedColumnTitle);
   });
 
   return (
@@ -110,7 +113,7 @@ const TaskModal: React.FC<{ cardData: Card; columnId: number; closeModalFunc: ()
           <DeadLineDate>{card.dueDate}</DeadLineDate>
         </ContactDeadLineWrapper>
         <CategoryWrapper>
-          <ColumnName status={columnTitle} />
+          <ColumnName status={columnTitleData} />
           <DivisionWrapper>
             <Division alt="category-division" width={10} height={20} />
           </DivisionWrapper>

--- a/components/Modal/TaskModal/TaskModal.tsx
+++ b/components/Modal/TaskModal/TaskModal.tsx
@@ -66,6 +66,12 @@ const TaskModal: React.FC<{ cardData: Card; columnId: number; closeModalFunc: ()
 
   const handleTaskModalClose = () => {
     if (isCardUpdated) {
+      setCards((prev) => {
+        const cardIndex = prev[columnId].findIndex((v) => v.id == card.id);
+        const cardList = prev[columnId];
+        cardList[cardIndex] = card;
+        return { ...prev, [card.columnId]: cardList };
+      });
       //status를 다른 칼럼으로 옮겼을 시 즉시 반영
       if (columnId !== card.columnId) {
         setCards((prev) => {

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -16,6 +16,25 @@ export const dashboardColorAtom = atom<string>(`${DASHBOARD_COLOR[0]}`);
 
 export const cardsAtom = atom<{ [columnId: number]: Card[] }>({});
 
+export const cardAtom = atom<Card>({
+  id: 0,
+  title: "string",
+  description: "string",
+  tags: [],
+  dueDate: "string",
+  assignee: {
+    nickname: "string",
+    id: 0,
+  },
+  imageUrl: "string",
+  teamId: "string",
+  dashboardId: 0,
+  columnId: 0,
+  createdAt: "string",
+  updatedAt: "string",
+});
+export const isCardUpdatedAtom = atom<boolean>(false);
+
 export const cardsTotalCountAtom = atom<{ [columnId: number]: number }>({});
 
 export const commentScrollAtom = atom<boolean>(false);


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- [x] EditTaskModal에서 태스크를 수정하면 열려 있던 TaskModal에 바로 반영하고, 컬럼 이동도 바로 반영합니다.
- [x] 마감일, 이미지를 아예 없애는 수정은 안 되어 있었는데 아예 없앨 수 있도록 구현했습니다.
- [ ] 담당자도 없앨 수 있어야 하는데, ContactDropdown.tsx까지 볼 기력이 없어요..
- [x] 담당자 이미지 삽입
- [x] state(컬럼이름)드롭다운을 연채로 수정버튼을 누르면 다음 수정 때 계속 열려 있는 문제 => 항상 닫혀 있도록 수정
- [x] state(컬럼이름) 드롭다운이 이전에 선택했던 요소를 가리키고 있는 문제 => 현재 선택된 요소를 가리키고 있도록 수정
- [x] useEffect 아래로 내리면 에러나는 문제 => 해결
***

## 📷 ScreenShot
---

https://github.com/SWCF-8TEAM/taskify/assets/144668146/5da7c061-07af-4d6d-ac48-3d95d4134a55

용량제한으로 아주 짧게ㅎㅎ

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
