### PR TITLE
🍀 refactor: EditTaskModal 리팩

### DIFF
--- a/components/Modal/AddTaskModal.tsx
+++ b/components/Modal/AddTaskModal.tsx
@@ -71,7 +71,6 @@ const AddTaskModal = ({ closeModalFunc, columnId }: AddTaskModalProps) => {
     setTags([]);
   };
 
-  const handleSelectMember = (userId: number) => setAssigneeUserId(userId);
   const handleTitleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => setTitle(event.target.value);
   const handleDescriptionChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => setDescription(event.target.value);
 
@@ -82,11 +81,11 @@ const AddTaskModal = ({ closeModalFunc, columnId }: AddTaskModalProps) => {
   return (
     <Wrapper ref={modalRef}>
       <TodoTitle>할 일 생성</TodoTitle>
-      <ContactDropdown onSelectMember={handleSelectMember} dashboardId={dashboardId} />
+      <ContactDropdown dashboardId={dashboardId} />
       <ModalInput $inputType="제목" label="제목" value={title} onChange={handleTitleChange} />
       <ModalInput $inputType="설명" label="설명" value={description} onChange={handleDescriptionChange} />
       <ModalInput $inputType="마감일" label="마감일" value={dueDate} />
-      <TagInput />
+      <TagInput isModify={true} />
       <ImageUploadInput type="modal" atomtype="cardImage" />
       <ButtonWrapper>
         <ButtonSet
@@ -109,9 +108,12 @@ export default AddTaskModal;
 
 const Wrapper = styled.div`
   width: 50.6rem;
+  height: 85vh;
 
   padding: 3.2rem 2.8rem 2.8rem 2.8rem;
   border-radius: 8px;
+
+  overflow-y: auto;
 
   display: flex;
   flex-direction: column;

--- a/components/Modal/EditTaskModal.tsx
+++ b/components/Modal/EditTaskModal.tsx
@@ -1,60 +1,48 @@
-import { getCard, putCard } from "@/api/cards";
+import { putCard } from "@/api/cards";
+import { Card } from "@/api/cards/cards.types";
 import { postCardImage } from "@/api/columns";
-import { Card, CardProps, PutCardProps } from "@/api/cards/cards.types";
 import ContactDropdown from "@/components/Modal/ModalInput/ContactDropdown";
 import ImageUploadInput from "@/components/Modal/ModalInput/ImageUploadInput";
 import StateDropdown from "@/components/Modal/ModalInput/StateDropdown";
 import TagInput from "@/components/Modal/ModalInput/TagInput";
 import ButtonSet from "@/components/common/Buttons/ButtonSet";
+import { cardAssigneeIdAtom, cardAtom, cardImageAtom, dueDateAtom, isCardUpdatedAtom, tagAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
-import { useRouter } from "next/router";
-import { cardAssigneeIdAtom, cardAtom, cardImageAtom, cardsAtom, dueDateAtom, isCardUpdatedAtom, statusAtom, tagAtom } from "@/states/atoms";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import ModalInput from "./ModalInput/ModalInput";
 
 interface EditTaskModalProps {
-  cardId: number;
+  card: Card;
   onEdit?: () => void;
   onCancel: () => void;
 }
 
-const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
-  const [cardData, setCardData] = useState<Card | null>(null);
-  const [cards, setCards] = useAtom(cardsAtom);
+const EditTaskModal = ({ card, onCancel, onEdit }: EditTaskModalProps) => {
+  const [cardData, setCardData] = useState<Card>(card);
   const [tags, setTags] = useAtom(tagAtom);
   const [dueDate, setDueDate] = useAtom(dueDateAtom);
   const [cardImage, setCardImage] = useAtom(cardImageAtom);
-  const [status, setStatus] = useAtom(statusAtom);
   const [assigneeUserId, setAssigneeUserId] = useAtom(cardAssigneeIdAtom);
-  const [updatedCard, setUpdatedCard] = useAtom(cardAtom); //바로 업데이트를 위한 조타이
-  const [isCardUpdated, setIsCardUpdated] = useAtom(isCardUpdatedAtom);
-
-  const [isImageDeleteClick, setIsImageDeleteClick] = useState(false);
+  const [, setUpdatedCard] = useAtom(cardAtom); //바로 업데이트를 위한 조타이
+  const [, setIsCardUpdated] = useAtom(isCardUpdatedAtom);
+  const [isImageDeleteClick, setIsImageDeleteClick] = useState(false); //이미지 삭제를 감지
   const [token, setToken] = useState<string | null>(null);
-  const router = useRouter();
-  const { boardid } = router.query;
 
   const handleColumnChange = (newColumnId: number) => {
-    if (cardData) {
-      setCardData({
-        ...cardData,
-        columnId: newColumnId,
-      });
-    }
-  };
-
-  const handleSelectMember = (userId: number) => {
-    setAssigneeUserId(userId);
+    setCardData({
+      ...cardData,
+      columnId: newColumnId,
+    });
   };
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    if (cardData) setCardData({ ...cardData, title: e.target.value });
+    setCardData({ ...cardData, title: e.target.value });
   };
 
   const handleDescriptionChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    if (cardData) setCardData({ ...cardData, description: e.target.value });
+    setCardData({ ...cardData, description: e.target.value });
   };
 
   const handleSubmit = async () => {
@@ -88,6 +76,7 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
     const updatedCard = await putCard(updatedCardData);
 
     if (updatedCard) {
+      console.log(updatedCard);
       setUpdatedCard({ ...updatedCard });
       setIsCardUpdated(true);
       if (onEdit) onEdit();
@@ -107,53 +96,42 @@ const EditTaskModal = ({ cardId, onCancel, onEdit }: EditTaskModalProps) => {
 
   useEffect(() => {
     setToken(localStorage.getItem("accessToken"));
-
-    const fetchCardData = async () => {
-      const data = await getCard({ cardId, token });
-      if (data) {
-        setCardData(data);
-        setDueDate(data.dueDate);
-        if (data.assignee) setAssigneeUserId(data.assignee.id);
-        setTags(data.tags);
-      }
-    };
-
-    if (token) fetchCardData();
+    if (token) {
+      if (cardData.assignee) setAssigneeUserId(cardData.assignee.id);
+      setDueDate(cardData.dueDate);
+      setTags(cardData.tags);
+    }
   }, [token]);
   return (
-    <>
-      {cardData && (
-        <Wrapper>
-          <TodoTitle>할 일 수정</TodoTitle>
-          <DropdownWrapper>
-            <StateDropdown dashboardId={cardData.dashboardId} defaultColumnId={cardData.columnId} onColumnSelect={handleColumnChange} />
-            {cardData.assignee ? (
-              <ContactDropdown onSelectMember={handleSelectMember} dashboardId={cardData.dashboardId} assigneeNickname={cardData.assignee.nickname} />
-            ) : (
-              <ContactDropdown onSelectMember={handleSelectMember} dashboardId={cardData.dashboardId} />
-            )}
-          </DropdownWrapper>
-          <ModalInput label="제목" $inputType="제목" value={cardData.title} onChange={handleTitleChange} />
-          <ModalInput $inputType="설명" label="설명" value={cardData.description} onChange={handleDescriptionChange} />
-          <ModalInput label="마감일" $inputType="마감일" value={cardData.dueDate} />
-          <TagInput initialTags={cardData.tags} />
-          <ImageUploadInput atomtype="cardImage" type="modal" initialImageUrl={cardData.imageUrl} handleDeleteClick={setIsImageDeleteClick} />
-          <ButtonWrapper>
-            <ButtonSet
-              type="modalSet"
-              onClickLeft={() => {
-                onCancel();
-                deleteAtomData();
-              }}
-              onClickRight={handleSubmit}
-              isRightDisabled={!cardData.title || !cardData.description}
-            >
-              수정
-            </ButtonSet>
-          </ButtonWrapper>
-        </Wrapper>
-      )}
-    </>
+    <Wrapper>
+      <TodoTitle>할 일 수정</TodoTitle>
+      <DropdownWrapper>
+        <StateDropdown dashboardId={cardData.dashboardId} defaultColumnId={cardData.columnId} onColumnSelect={handleColumnChange} />
+        {cardData.assignee ? (
+          <ContactDropdown dashboardId={cardData.dashboardId} assigneeNickname={cardData.assignee.nickname} />
+        ) : (
+          <ContactDropdown dashboardId={cardData.dashboardId} />
+        )}
+      </DropdownWrapper>
+      <ModalInput label="제목" $inputType="제목" value={cardData.title} onChange={handleTitleChange} />
+      <ModalInput $inputType="설명" label="설명" value={cardData.description} onChange={handleDescriptionChange} />
+      <ModalInput label="마감일" $inputType="마감일" value={cardData.dueDate} />
+      <TagInput />
+      <ImageUploadInput atomtype="cardImage" type="modal" initialImageUrl={cardData.imageUrl} handleDeleteClick={setIsImageDeleteClick} />
+      <ButtonWrapper>
+        <ButtonSet
+          type="modalSet"
+          onClickLeft={() => {
+            onCancel();
+            deleteAtomData();
+          }}
+          onClickRight={handleSubmit}
+          isRightDisabled={!cardData.title || !cardData.description}
+        >
+          수정
+        </ButtonSet>
+      </ButtonWrapper>
+    </Wrapper>
   );
 };
 

--- a/components/Modal/EditTaskModal.tsx
+++ b/components/Modal/EditTaskModal.tsx
@@ -76,7 +76,6 @@ const EditTaskModal = ({ card, onCancel, onEdit }: EditTaskModalProps) => {
     const updatedCard = await putCard(updatedCardData);
 
     if (updatedCard) {
-      console.log(updatedCard);
       setUpdatedCard({ ...updatedCard });
       setIsCardUpdated(true);
       if (onEdit) onEdit();
@@ -116,7 +115,7 @@ const EditTaskModal = ({ card, onCancel, onEdit }: EditTaskModalProps) => {
       <ModalInput label="제목" $inputType="제목" value={cardData.title} onChange={handleTitleChange} />
       <ModalInput $inputType="설명" label="설명" value={cardData.description} onChange={handleDescriptionChange} />
       <ModalInput label="마감일" $inputType="마감일" value={cardData.dueDate} />
-      <TagInput />
+      <TagInput isModify={true} />
       <ImageUploadInput atomtype="cardImage" type="modal" initialImageUrl={cardData.imageUrl} handleDeleteClick={setIsImageDeleteClick} />
       <ButtonWrapper>
         <ButtonSet
@@ -139,9 +138,11 @@ export default EditTaskModal;
 
 const Wrapper = styled.div`
   width: 50.6rem;
-
+  height: 85vh;
   padding: 3.2rem 2.8rem 2.8rem 2.8rem;
   border-radius: 8px;
+
+  overflow-y: auto;
 
   display: flex;
   flex-direction: column;

--- a/components/Modal/ModalInput/ContactDropdown.tsx
+++ b/components/Modal/ModalInput/ContactDropdown.tsx
@@ -21,9 +21,10 @@ const ContactDropdown = ({ dashboardId, assigneeNickname }: ContactDropdownProps
   const [showList, setShowList] = useState(false);
   const [filteredMembers, setFilteredMembers] = useState<Member[]>([]);
   const [, setAssigneeId] = useAtom(cardAssigneeIdAtom);
-  const token = localStorage.getItem("accessToken");
+  const [isSelected, setIsSelected] = useState(true);
 
   useEffect(() => {
+    const token = localStorage.getItem("accessToken");
     const fetchMembers = async () => {
       try {
         const memberData = await getMembers({ dashboardId, token });
@@ -44,7 +45,7 @@ const ContactDropdown = ({ dashboardId, assigneeNickname }: ContactDropdownProps
     };
 
     fetchMembers();
-  }, [dashboardId, token]);
+  }, [dashboardId]);
 
   const toggleList = () => {
     setShowList(!showList);
@@ -59,7 +60,8 @@ const ContactDropdown = ({ dashboardId, assigneeNickname }: ContactDropdownProps
     const matchedMembers = membersData.filter((membersData) => membersData.nickname.toLowerCase().includes(input.toLowerCase()));
 
     setFilteredMembers(matchedMembers);
-
+    setAssigneeId(null); //input에 뭐 타이핑하면 무조건 담당자는 없음, 꼭 list중에서 Select해야함
+    setIsSelected(false); //선택되지 않았음을 사용자에게 보여주기 위해 프로필을 지움
     if (input) {
       setShowList(true);
     } else {
@@ -73,6 +75,7 @@ const ContactDropdown = ({ dashboardId, assigneeNickname }: ContactDropdownProps
     setFilter(membersData.nickname);
     setShowList(false);
     setAssigneeId(membersData.userId);
+    setIsSelected(true);
   };
 
   return (
@@ -80,9 +83,11 @@ const ContactDropdown = ({ dashboardId, assigneeNickname }: ContactDropdownProps
       <Text>담당자</Text>
       <Container>
         <InputContainer>
-          {selectedMember && selectedMember.profileImageUrl && <SelectProfileIcon src={selectedMember.profileImageUrl} alt="Profile" />}
+          {selectedMember && selectedMember.profileImageUrl && (
+            <SelectProfileIcon className={`${isSelected ? "" : "hideProfile"}`} src={selectedMember.profileImageUrl} alt="Profile" />
+          )}
           {selectedMember && !selectedMember.profileImageUrl && (
-            <SelectedNoProfileImage>
+            <SelectedNoProfileImage className={`${isSelected ? "" : "hideProfile"}`}>
               <NoProfileImage id={selectedMember.userId} nickname={selectedMember.nickname} />
             </SelectedNoProfileImage>
           )}
@@ -163,6 +168,10 @@ const SelectProfileIcon = styled.img`
 
   transform: translateY(-50%);
   object-fit: cover;
+
+  &.hideProfile {
+    display: none;
+  }
 `;
 const SelectedNoProfileImage = styled.div`
   width: 2.4rem;
@@ -175,6 +184,9 @@ const SelectedNoProfileImage = styled.div`
   border-radius: 50%;
 
   transform: translateY(-50%);
+  &.hideProfile {
+    display: none;
+  }
 `;
 
 const Input = styled.input`

--- a/components/Modal/ModalInput/ContactDropdown.tsx
+++ b/components/Modal/ModalInput/ContactDropdown.tsx
@@ -1,27 +1,26 @@
-import { useState, ChangeEvent, useEffect } from "react";
-import styled from "styled-components";
+import { getMembers } from "@/api/members";
+import { Member } from "@/api/members/members.types";
 import DropdownIcon from "@/assets/icons/arrow-drop-down.svg";
 import CheckIcon from "@/assets/icons/check.svg";
+import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
+import { cardAssigneeIdAtom } from "@/states/atoms";
 import { Z_INDEX } from "@/styles/ZindexStyles";
 import { useAtom } from "jotai";
-import { cardAssigneeIdAtom } from "@/states/atoms";
-import { Member } from "@/api/members/members.types";
-import { getMembers } from "@/api/members";
-import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
-import { DeviceSize } from "@/styles/DeviceSize";
+import { ChangeEvent, useEffect, useState } from "react";
+import styled from "styled-components";
 
 interface ContactDropdownProps {
   dashboardId: number;
   assigneeNickname?: string | null;
-  onSelectMember?: (userId: number) => void;
 }
 
-const ContactDropdown = ({ dashboardId, assigneeNickname, onSelectMember }: ContactDropdownProps) => {
+const ContactDropdown = ({ dashboardId, assigneeNickname }: ContactDropdownProps) => {
   const [membersData, setMembersData] = useState<Member[]>([]);
   const [filter, setFilter] = useState("");
   const [selectedMember, setSelectedMember] = useState<Member | null>(null);
   const [showList, setShowList] = useState(false);
   const [filteredMembers, setFilteredMembers] = useState<Member[]>([]);
+  const [, setAssigneeId] = useAtom(cardAssigneeIdAtom);
   const token = localStorage.getItem("accessToken");
 
   useEffect(() => {
@@ -47,7 +46,6 @@ const ContactDropdown = ({ dashboardId, assigneeNickname, onSelectMember }: Cont
     fetchMembers();
   }, [dashboardId, token]);
 
-  const [, setAssigneeId] = useAtom(cardAssigneeIdAtom);
   const toggleList = () => {
     setShowList(!showList);
     if (!showList) {
@@ -74,7 +72,6 @@ const ContactDropdown = ({ dashboardId, assigneeNickname, onSelectMember }: Cont
     setSelectedMember(membersData);
     setFilter(membersData.nickname);
     setShowList(false);
-    if (onSelectMember) onSelectMember(membersData.userId);
     setAssigneeId(membersData.userId);
   };
 

--- a/components/Modal/ModalInput/StateDropdown.tsx
+++ b/components/Modal/ModalInput/StateDropdown.tsx
@@ -19,9 +19,8 @@ const StateDropdown = ({ dashboardId, defaultColumnId, onColumnSelect }: StateDr
   const [columns, setColumns] = useAtom(columnsAtom);
   const [selectedId, setSelectedId] = useAtom(selectedIdAtom);
 
-  const token = localStorage.getItem("accessToken");
-
   useEffect(() => {
+    const token = localStorage.getItem("accessToken");
     //처음엔 드롭다운 무조건 닫혀있는 상태
     setIsOpen(false);
     const fetchData = async () => {
@@ -37,7 +36,7 @@ const StateDropdown = ({ dashboardId, defaultColumnId, onColumnSelect }: StateDr
     };
 
     fetchData();
-  }, [dashboardId, token]);
+  }, [dashboardId]);
 
   const toggleDropdown = () => {
     setIsOpen((prev) => !prev);

--- a/components/Modal/ModalInput/TagInput.tsx
+++ b/components/Modal/ModalInput/TagInput.tsx
@@ -24,11 +24,7 @@ const Tags = ({ handleOnClick, tagValue }: TagsProps) => {
   );
 };
 
-interface TagInputProps {
-  initialTags?: string[]; // 여기에 initialTags prop의 타입을 추가
-}
-
-const TagInput = ({ initialTags = [] }: TagInputProps) => {
+const TagInput = () => {
   const [inputValue, setInputValue] = useState("");
   const [tagValue, setTagValue] = useAtom(tagAtom);
 
@@ -54,16 +50,12 @@ const TagInput = ({ initialTags = [] }: TagInputProps) => {
     setInputValue("");
   };
 
-  useEffect(() => {
-    setTagValue(initialTags);
-  }, []);
-
   return (
     <InputBox>
       <Label>태그</Label>
       <InputArea>
         {tagValue && <Tags handleOnClick={handleDeleteTag} tagValue={tagValue} />}
-        <StyledInput type="text" value={inputValue} onChange={handleInputChange} placeholder={tagValue.length === 0 ? "입력 후 Enter" : ""} onKeyDown={handlePressEnter} />
+        <StyledInput type="text" value={inputValue} onChange={handleInputChange} placeholder={tagValue.length == 0 ? "입력 후 Enter" : ""} onKeyDown={handlePressEnter} />
       </InputArea>
     </InputBox>
   );

--- a/components/Modal/ModalInput/TagInput.tsx
+++ b/components/Modal/ModalInput/TagInput.tsx
@@ -56,8 +56,9 @@ const TagInput = ({ isModify = false }: { isModify?: boolean }) => {
     if (event.key !== "Enter") return;
     if (event.nativeEvent.isComposing) return;
     if (!inputValue) return;
-    if (tagValue.filter((v) => v == inputValue).length === 0) {
-      setTagValue((prev) => [...prev, inputValue]);
+    const trimedValue = inputValue.split(" ").join("");
+    if (tagValue.filter((v) => v == trimedValue).length === 0) {
+      setTagValue((prev) => [...prev, trimedValue]);
     }
     setInputValue("");
   };

--- a/components/Modal/ModalInput/TagInput.tsx
+++ b/components/Modal/ModalInput/TagInput.tsx
@@ -12,8 +12,16 @@ interface TagsProps {
 }
 
 const Tags = ({ handleOnClick, tagValue, isModifyMode }: TagsProps) => {
+  const scrollRef = useRef<HTMLDivElement>(null); //태그가 추가되어 스크롤이 생기면 오른쪽으로 스크롤이 이동하여 항상 최근태그를 보도록함
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollRef.current.scrollWidth;
+    }
+  }, [tagValue]);
+
   return (
-    <TagArea>
+    <TagArea ref={scrollRef}>
       {tagValue.map((tag) => {
         return (
           <div key={tag} style={{ cursor: "pointer" }}>
@@ -34,12 +42,7 @@ const TagInput = ({ isModify = false }: { isModify?: boolean }) => {
   const handleClickOutside = (event: MouseEvent) => {
     if (containerRef.current && !containerRef.current.contains(event.target as Node)) setIsTagModify(false);
   };
-  useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  });
+
   const handleInputChange = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     setInputValue(e.target.value);
   };
@@ -58,6 +61,14 @@ const TagInput = ({ isModify = false }: { isModify?: boolean }) => {
     }
     setInputValue("");
   };
+
+  useEffect(() => {
+    //태그인풋 외의 다른 곳을 클릭하면 편집모드 off
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  });
 
   return (
     <InputBox>
@@ -89,7 +100,7 @@ const Label = styled.label`
 `;
 
 const InputArea = styled.div`
-  height: 4.8rem;
+  height: 5.3rem;
 
   padding: 1.4rem;
   border: 1px solid var(--Grayd9);
@@ -133,13 +144,13 @@ const TagArea = styled.div`
   display: flex;
   gap: 0.8rem;
 
-  max-width: 70%;
+  max-width: 100%;
   height: 3rem;
   overflow-x: scroll;
   overflow-y: hidden;
 
   &::-webkit-scrollbar {
-    height: 0.4rem;
+    height: 0.7rem;
     border-radius: 0.6rem;
   }
   &::-webkit-scrollbar-thumb {

--- a/components/Modal/TaskModal/TaskModal.tsx
+++ b/components/Modal/TaskModal/TaskModal.tsx
@@ -83,6 +83,13 @@ const TaskModal: React.FC<{ cardData: Card; columnId: number; closeModalFunc: ()
           const cardList = [...cards[columnId].filter((v) => v.id !== card.id)];
           return { ...prev, [columnId]: cardList };
         });
+        //컬럼 개수 조정
+        setCardsTotalCount((prev) => {
+          return { ...prev, [columnId]: prev[columnId] - 1 };
+        });
+        setCardsTotalCount((prev) => {
+          return { ...prev, [card.columnId]: prev[card.columnId] + 1 };
+        });
       }
     }
     closeModalFunc();

--- a/components/Modal/TaskModal/TaskModal.tsx
+++ b/components/Modal/TaskModal/TaskModal.tsx
@@ -164,7 +164,7 @@ const TaskModal: React.FC<{ cardData: Card; columnId: number; closeModalFunc: ()
       {isEditModalOpen && (
         <ModalWrapper>
           <EditTaskModal
-            cardId={card.id}
+            card={card}
             onCancel={closeEditModal}
             onEdit={() => {
               closeEditModal();

--- a/components/Table/InvitedDashboard.tsx
+++ b/components/Table/InvitedDashboard.tsx
@@ -51,6 +51,7 @@ const InvitedDashboard = () => {
   };
 
   useEffect(() => {
+    setInvitations([]);
     loadInvitations();
   }, []);
 

--- a/components/common/Chip/Tag.tsx
+++ b/components/common/Chip/Tag.tsx
@@ -14,12 +14,12 @@ const Tag = ({ tag, handleOnClick, isModifyMode }: { tag: string; handleOnClick:
       {tag}
       {isTagModify && isModifyMode && (
         <div
-          style={{ height: "1.8rem" }}
+          style={{ height: "1.6rem" }}
           onClick={() => {
             handleOnClick(tag);
           }}
         >
-          <TiDelete size={18} />
+          <TiDelete size={16} />
         </div>
       )}
     </Container>
@@ -39,7 +39,7 @@ const Container = styled.span<{ $bgColor: string; $textColor: string }>`
 
   color: ${(props) => props.$textColor};
   text-align: center;
-  font-size: 1.5rem;
+  font-size: 1.3rem;
 
   @media screen and (max-width: ${DeviceSize.mobile}) {
     font-size: 1rem;

--- a/components/common/Chip/Tag.tsx
+++ b/components/common/Chip/Tag.tsx
@@ -1,13 +1,27 @@
 import { TAG_COLOR } from "@/constants/ColorConstant";
 import { DeviceSize } from "@/styles/DeviceSize";
 import styled from "styled-components";
+import { TiDelete } from "react-icons/ti";
+import { isTagModifyAtom } from "@/states/atoms";
+import { useAtom } from "jotai";
 
-const Tag = ({ tag }: { tag: string }) => {
+const Tag = ({ tag, handleOnClick, isModifyMode }: { tag: string; handleOnClick: (targetTag: string) => void; isModifyMode?: boolean }) => {
+  const [isTagModify] = useAtom(isTagModifyAtom);
   const tagNum = tag?.charCodeAt(0) % 10;
 
   return (
     <Container $bgColor={TAG_COLOR[tagNum].bgColor} $textColor={TAG_COLOR[tagNum].textColor}>
       {tag}
+      {isTagModify && isModifyMode && (
+        <div
+          style={{ height: "1.8rem" }}
+          onClick={() => {
+            handleOnClick(tag);
+          }}
+        >
+          <TiDelete size={18} />
+        </div>
+      )}
     </Container>
   );
 };
@@ -18,14 +32,14 @@ const Container = styled.span<{ $bgColor: string; $textColor: string }>`
   display: inline-flex;
   justify-content: center;
   align-items: center;
-  gap: 1rem;
+  gap: 0.5rem;
 
   border-radius: 4px;
   background-color: ${(props) => props.$bgColor};
 
   color: ${(props) => props.$textColor};
   text-align: center;
-  font-size: 1.2rem;
+  font-size: 1.5rem;
 
   @media screen and (max-width: ${DeviceSize.mobile}) {
     font-size: 1rem;

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -54,3 +54,5 @@ export const isOpenAtom = atom(false);
 export const statusAtom = atom("로딩 중");
 
 export const selectedIdAtom = atom<number | null>(null);
+
+export const isTagModifyAtom = atom<boolean>(false);


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- [x] 코드 전체적으로 리팩했습니다. (불필요한 변수,함수 삭제 )
- [x] 태스크의 컬럼을 옮길 시 컬럼의 개수가 변하도록 구현
- [x] 담당자 삭제 기능 구현
담당자 input을 입력하고 있을 때는 프로필 이미지가 뜨지 않게 하여 사용자가 담당자를 선택하지 않았음을 알려주고자 했습니다.
<img width="453" alt="스크린샷 2024-01-03 오후 4 40 04" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/847df799-2b88-4901-a859-f1017a489890">

⭐️테스트 하시다 에러 발생하면 알려주세용!

### 태그 인풋 관련 사항도 실수로 같은 브랜치에서 작업하고 push 했네요..
- [x] 태그 수정할 때 x아이콘 보이고 클릭시 삭제
- [x] 태그 많이 입력하면 스크롤 생기는데, 스크롤이 항상 마지막 데이터를 보도록 수정
- [x] 태스크 수정, 생성 모달 얘기했던대로 높이 적당히 고정하고 스크롤 생기게 했어요
<img width="552" alt="스크린샷 2024-01-03 오후 7 30 13" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/e7f848f7-809d-4c01-92fa-9fafa19713bd">

***

## 📷 ScreenShot
---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
