### PR TITLE
🍀 refactor: 대시보드 색깔, 이름 수정시 사이드메뉴 헤더 바로 반영

### DIFF
--- a/api/dashboards/dashboards.types.ts
+++ b/api/dashboards/dashboards.types.ts
@@ -59,8 +59,10 @@ export interface PostDashboardInvitationsProps {
 }
 
 export interface PutDashboardProps {
-  dashboardId: string;
-  token: string;
+  dashboardId: number;
+  token: string | null;
+  title: string;
+  color: string;
 }
 
 export interface PostDashboardProps {

--- a/api/dashboards/index.ts
+++ b/api/dashboards/index.ts
@@ -131,16 +131,13 @@ export const postDashboardInvitations = async ({ email, dashboardId, token }: Po
   }
 };
 
-export const putDashboard = async ({
-  dashboardId = "193",
-  token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTMsInRlYW1JZCI6IjEtMDgiLCJpYXQiOjE3MDM1NjYyOTgsImlzcyI6InNwLXRhc2tpZnkifQ.zNaGd4uESNMzrDDHokuybQNJs_CkFLY7SpYKgafPBl0",
-}: PutDashboardProps): Promise<Dashboard | null> => {
+export const putDashboard = async ({ dashboardId, title, color, token }: PutDashboardProps): Promise<Dashboard | null> => {
   try {
     const res = await instance.put(
       ENDPOINTS.DASHBOARDS.PUT(dashboardId),
       {
-        title: "api 만든 사람 완전히 망해라",
-        color: "#000000",
+        title,
+        color,
       },
       {
         headers: {

--- a/components/Table/EditDashboard.tsx
+++ b/components/Table/EditDashboard.tsx
@@ -5,18 +5,38 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import ToastModal from "@/components/Modal/ToastModal";
 import { toast } from "react-toastify";
 import { useRouter } from "next/router";
-import { getDashboard } from "@/api/dashboards";
+import { getDashboard, putDashboard } from "@/api/dashboards";
 import { Dashboard } from "@/api/dashboards/dashboards.types";
+import { useAtom } from "jotai";
+import { dashboardListAtom, dashboardColorAtom } from "@/states/atoms";
 
 const EditDashboard = () => {
   const [toastVisible, setToastVisible] = useState(false);
   const [dashboard, setDashboard] = useState<Dashboard>();
   const router = useRouter();
   const { boardid } = router.query;
+  const [, setEditDashboard] = useAtom(dashboardListAtom);
+  const [newTitle, setNewTitle] = useState("");
+  const [dashboardColor, setDashboardColor] = useAtom(dashboardColorAtom);
 
-  const handleClick = () => {
+  const handleClick = async () => {
     toast("변경이 완료되었습니다.");
     setToastVisible((prev) => !prev);
+
+    if (boardid && newTitle) {
+      const updatedDashboard = await putDashboard({
+        dashboardId: Number(boardid),
+        token: localStorage.getItem("accessToken"),
+        title: newTitle,
+        color: dashboardColor,
+      });
+
+      if (updatedDashboard) {
+        setDashboard(updatedDashboard);
+        setEditDashboard(updatedDashboard);
+        setDashboardColor(updatedDashboard.color);
+      }
+    }
   };
 
   useEffect(() => {
@@ -38,7 +58,7 @@ const EditDashboard = () => {
       </Header>
       <Form>
         <Label>대시보드 이름</Label>
-        <Input placeholder="변경할 이름을 입력해 주세요." />
+        <Input onChange={(e) => setNewTitle(e.target.value)} placeholder="변경할 이름을 입력해 주세요." />
       </Form>
       <ButtonWrapper>
         <Button onClick={handleClick}> 변경</Button>

--- a/components/common/Nav/DashboardNav.tsx
+++ b/components/common/Nav/DashboardNav.tsx
@@ -1,13 +1,16 @@
 import { getDashboard } from "@/api/dashboards";
 import { Dashboard } from "@/api/dashboards/dashboards.types";
 import NavContainer from "@/components/common/Nav/NavContainer";
+import { useAtom } from "jotai";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+import { dashboardListAtom } from "@/states/atoms";
 
 const DashboardNav = () => {
   const router = useRouter();
   const { boardid } = router.query;
   const [dashboard, setDashboard] = useState<Dashboard>();
+  const [editDashboards, setEditDashboards] = useAtom(dashboardListAtom);
 
   useEffect(() => {
     const loadDashboardData = async () => {
@@ -15,7 +18,7 @@ const DashboardNav = () => {
       if (res !== null) setDashboard(res);
     };
     loadDashboardData();
-  }, [boardid]);
+  }, [boardid, editDashboards]);
 
   return <>{dashboard && <NavContainer title={dashboard.title} $isDashboard={true} createdByMe={dashboard.createdByMe} />}</>;
 };

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -19,6 +19,7 @@ import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useInfiniteScrollNavigator } from "@/hooks/useInfiniteScrollNavigator";
 import { FaArrowUpWideShort } from "react-icons/fa6";
 import { useRouter } from "next/router";
+import { dashboardListAtom } from "@/states/atoms";
 
 interface DashboardProps {
   boardId: number;
@@ -50,6 +51,7 @@ const SideMenu = () => {
   const [cursorId, setCursorId] = useState<number | null>(null);
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
   const [invitations, setInvitations] = useAtom(invitationsAtom); // 초대 목록!!
+  const [editDashboard, setEditDashboard] = useAtom(dashboardListAtom);
   const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const wrapperRef = useRef(null);
 
@@ -66,44 +68,18 @@ const SideMenu = () => {
     setIsPopupVisible((prev) => !prev);
   };
 
-  const loadDashboards = async () => {
-    if (dashboards.length > 0 && cursorId == null) {
-      return;
-    }
-    setIsLoading(true);
-    const data = await getDashboardList({
-      cursorId,
-      size: PAGE_SIZE,
-      token: localStorage.getItem("accessToken"),
-      navigationMethod: "infiniteScroll",
-    });
-
-    if (data) {
-      setDashboards((prev) => [...prev, ...data.dashboards]);
-      // setInvitations([data.dashboards]);
-      setCursorId(data.cursorId);
-    }
-    setIsLoading(false);
-  };
-
-  const { targetRef, setIsLoading } = useInfiniteScroll({ callbackFunc: loadDashboards });
-
   useEffect(() => {
-    loadDashboards();
-  }, [cursorId]);
-
-  // useEffect(() => {
-  //   const loadDashboardList = async () => {
-  //     const res = await getDashboardList({
-  //       token: localStorage.getItem("accessToken"),
-  //       navigationMethod: "infiniteScroll",
-  //     });
-  //     if (res && res.dashboards) {
-  //       setDashboards(...[res.dashboards]);
-  //     }
-  //   };
-  //   loadDashboardList();
-  // }, [invitations]);
+    const loadDashboardList = async () => {
+      const res = await getDashboardList({
+        token: localStorage.getItem("accessToken"),
+        navigationMethod: "infiniteScroll",
+      });
+      if (res && res.dashboards) {
+        setDashboards(...[res.dashboards]);
+      }
+    };
+    loadDashboardList();
+  }, [editDashboard, invitations]);
 
   useEffect(() => {
     document.addEventListener("mousedown", handleClickOutside);

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -3,6 +3,7 @@ import { Invitation } from "@/api/invitations/invitations.types";
 import { DASHBOARD_COLOR } from "@/constants/ColorConstant";
 import { Columns } from "@/api/columns/columns.types";
 import { Card } from "@/api/cards/cards.types";
+import { Dashboard } from "@/api/dashboards/dashboards.types";
 
 // 현재 활성화된 드롭다운의 식별자를 저장하는 아톰
 export const activeDropdownAtom = atom<string | null>(null);
@@ -15,6 +16,8 @@ export const totalColumnsAtom = atom(0);
 export const dashboardColorAtom = atom<string>(`${DASHBOARD_COLOR[0]}`);
 
 export const cardsAtom = atom<{ [columnId: number]: Card[] }>({});
+
+export const dashboardListAtom = atom<Dashboard | null>(null);
 
 export const cardAtom = atom<Card>({
   id: 0,


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- 대시보드 색, 이름 변경시 헤더랑 사이드메뉴에 바로 반영되게 했습니다.
***

## 📷 ScreenShot
---
https://github.com/SWCF-8TEAM/taskify/assets/72639353/30b8523c-5478-4335-a7d3-154dcb51a663



## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
