### PR TITLE
🍀 refactor: Account Profile 기능 완성

### DIFF
--- a/api/users/index.ts
+++ b/api/users/index.ts
@@ -50,8 +50,8 @@ export const putUsers = async ({ nickname, profileImageUrl, token }: PutUsersPro
     const res = await instance.put(
       ENDPOINTS.USERS.PUT,
       {
-        nickname: nickname,
-        profileImageUrl: profileImageUrl,
+        nickname,
+        profileImageUrl,
       },
       {
         headers: {

--- a/components/Account/AccountProfile.tsx
+++ b/components/Account/AccountProfile.tsx
@@ -5,7 +5,7 @@ import ModalWrapper from "@/components/Modal/ModalWrapper";
 import Input from "@/components/Sign/SignInput/Input";
 import { NICKNAME_RULES, PLACEHOLDER } from "@/constants/InputConstant";
 import { useModal } from "@/hooks/useModal";
-import { profileImageAtom } from "@/states/atoms";
+import { profileImageAtom, profileImageUrlAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
@@ -19,6 +19,7 @@ interface ProfileFormData {
 
 const AccountProfile = () => {
   const [profileImage, setProfileImage] = useAtom(profileImageAtom);
+  const [profileImageUrl, setProfileImageUrl] = useAtom(profileImageUrlAtom);
   const [token, setToken] = useState<string | null>(null);
   const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const { control, handleSubmit, watch, setError, setValue, formState } = useForm({
@@ -43,6 +44,7 @@ const AccountProfile = () => {
         return;
       }
       imageUrl = profileImageRes.profileImageUrl;
+      setProfileImageUrl(imageUrl);
     }
 
     const userUpdateRes = await putUsers({ nickname: data.nickname, profileImageUrl: imageUrl, token });
@@ -65,6 +67,8 @@ const AccountProfile = () => {
         if (userData) {
           setValue("email", userData.email);
           setValue("nickname", userData.nickname);
+          setProfileImageUrl(userData.profileImageUrl);
+          console.log(profileImageUrl);
         }
       }
     };
@@ -78,7 +82,7 @@ const AccountProfile = () => {
         <Title>프로필</Title>
         <StyledForm onSubmit={handleSubmit(handleProfileSubmit)}>
           <Container>
-            <StyledImageUploadInput type="account" atomtype="profileImage" />
+            <StyledImageUploadInput type="account" atomtype="profileImage" initialImageUrl={profileImageUrl} />
             <InputWrapper>
               <Controller control={control} name="email" render={({ field }) => <StyledInput label="이메일" {...field} disabled />} />
               <Controller

--- a/components/Account/AccountProfile.tsx
+++ b/components/Account/AccountProfile.tsx
@@ -5,10 +5,10 @@ import ModalWrapper from "@/components/Modal/ModalWrapper";
 import Input from "@/components/Sign/SignInput/Input";
 import { NICKNAME_RULES, PLACEHOLDER } from "@/constants/InputConstant";
 import { useModal } from "@/hooks/useModal";
-import { profileImageAtom, userProfileImageUrlAtom } from "@/states/atoms";
+import { profileImageAtom, userProfileImageUrlAtom, userDataAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
-import { useEffect, useState, SetStateAction } from "react";
+import { SetStateAction, useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styled from "styled-components";
 
@@ -20,6 +20,7 @@ interface ProfileFormData {
 const AccountProfile = () => {
   const [profileImage, setProfileImage] = useAtom(profileImageAtom);
   const [userProfileImageUrl, setUserProfileImageUrl] = useAtom(userProfileImageUrlAtom);
+  const [userData, setUserData] = useAtom(userDataAtom);
   const [initialNickname, setInitialNickname] = useState("");
   const [isImageDeleted, setIsImageDeleted] = useState(false);
   const [token, setToken] = useState<string | null>(null);
@@ -40,7 +41,6 @@ const AccountProfile = () => {
   const handleProfileSubmit = async (data: ProfileFormData) => {
     let imageUrl = isImageDeleted ? null : userProfileImageUrl;
 
-    // 프로필 이미지 변경 확인
     if (profileImage && profileImage instanceof File) {
       const formData = new FormData();
       formData.append("image", profileImage);
@@ -54,10 +54,8 @@ const AccountProfile = () => {
       setUserProfileImageUrl(imageUrl);
     }
 
-    // 닉네임이 변경되었는지 확인
     const nicknameChanged = data.nickname !== initialNickname;
 
-    // 닉네임이나 프로필 이미지가 변경되었을 경우에만 업데이트 요청
     if (nicknameChanged || imageUrl !== userProfileImageUrl) {
       const userUpdateRes = await putUsers({
         nickname: data.nickname,
@@ -67,11 +65,11 @@ const AccountProfile = () => {
 
       if (userUpdateRes !== null) {
         openModalFunc();
+        setUserData(userUpdateRes);
       } else {
         console.error("Failed to update profile", Error);
       }
     } else {
-      // 변경 사항이 없을 경우
       alert("변경된 사항이 없습니다.");
     }
   };
@@ -88,7 +86,7 @@ const AccountProfile = () => {
         if (userData) {
           setValue("email", userData.email);
           setValue("nickname", userData.nickname);
-          setInitialNickname(userData.nickname); // 초기 닉네임 값 저장
+          setInitialNickname(userData.nickname);
           setUserProfileImageUrl(userData.profileImageUrl);
         }
       }

--- a/components/Account/AccountProfile.tsx
+++ b/components/Account/AccountProfile.tsx
@@ -8,7 +8,7 @@ import { useModal } from "@/hooks/useModal";
 import { profileImageAtom, userProfileImageUrlAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
-import { useEffect, useState } from "react";
+import { useEffect, useState, SetStateAction } from "react";
 import { Controller, useForm } from "react-hook-form";
 import styled from "styled-components";
 
@@ -21,6 +21,7 @@ const AccountProfile = () => {
   const [profileImage, setProfileImage] = useAtom(profileImageAtom);
   const [userProfileImageUrl, setUserProfileImageUrl] = useAtom(userProfileImageUrlAtom);
   const [initialNickname, setInitialNickname] = useState("");
+  const [isImageDeleted, setIsImageDeleted] = useState(false);
   const [token, setToken] = useState<string | null>(null);
   const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const { control, handleSubmit, watch, setError, setValue, formState } = useForm({
@@ -32,8 +33,12 @@ const AccountProfile = () => {
     closeModalFunc();
   };
 
+  const handleImageDelete = (value: SetStateAction<boolean>) => {
+    setIsImageDeleted(value);
+  };
+
   const handleProfileSubmit = async (data: ProfileFormData) => {
-    let imageUrl = userProfileImageUrl; // 기존 프로필 이미지 URL
+    let imageUrl = isImageDeleted ? null : userProfileImageUrl;
 
     // 프로필 이미지 변경 확인
     if (profileImage && profileImage instanceof File) {
@@ -98,7 +103,7 @@ const AccountProfile = () => {
         <Title>프로필</Title>
         <StyledForm onSubmit={handleSubmit(handleProfileSubmit)}>
           <Container>
-            <StyledImageUploadInput type="account" atomtype="profileImage" initialImageUrl={userProfileImageUrl} />
+            <StyledImageUploadInput type="account" atomtype="profileImage" initialImageUrl={userProfileImageUrl} handleDeleteClick={handleImageDelete} />
             <InputWrapper>
               <Controller control={control} name="email" render={({ field }) => <StyledInput label="이메일" {...field} disabled />} />
               <Controller

--- a/components/Account/AccountProfile.tsx
+++ b/components/Account/AccountProfile.tsx
@@ -5,7 +5,7 @@ import ModalWrapper from "@/components/Modal/ModalWrapper";
 import Input from "@/components/Sign/SignInput/Input";
 import { NICKNAME_RULES, PLACEHOLDER } from "@/constants/InputConstant";
 import { useModal } from "@/hooks/useModal";
-import { profileImageAtom, profileImageUrlAtom } from "@/states/atoms";
+import { profileImageAtom, userProfileImageUrlAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
@@ -19,7 +19,7 @@ interface ProfileFormData {
 
 const AccountProfile = () => {
   const [profileImage, setProfileImage] = useAtom(profileImageAtom);
-  const [profileImageUrl, setProfileImageUrl] = useAtom(profileImageUrlAtom);
+  const [userProfileImageUrl, setUserProfileImageUrl] = useAtom(userProfileImageUrlAtom);
   const [token, setToken] = useState<string | null>(null);
   const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const { control, handleSubmit, watch, setError, setValue, formState } = useForm({
@@ -44,14 +44,14 @@ const AccountProfile = () => {
         return;
       }
       imageUrl = profileImageRes.profileImageUrl;
-      setProfileImageUrl(imageUrl);
+      setUserProfileImageUrl(imageUrl);
     }
 
     const userUpdateRes = await putUsers({ nickname: data.nickname, profileImageUrl: imageUrl, token });
     if (userUpdateRes !== null) {
       openModalFunc();
     } else {
-      // setError를 사용하여 오류 처리
+      console.error("Failed to update profile", Error);
     }
   };
 
@@ -67,8 +67,8 @@ const AccountProfile = () => {
         if (userData) {
           setValue("email", userData.email);
           setValue("nickname", userData.nickname);
-          setProfileImageUrl(userData.profileImageUrl);
-          console.log(profileImageUrl);
+          setUserProfileImageUrl(userData.profileImageUrl);
+          console.log(userProfileImageUrl);
         }
       }
     };
@@ -82,7 +82,7 @@ const AccountProfile = () => {
         <Title>프로필</Title>
         <StyledForm onSubmit={handleSubmit(handleProfileSubmit)}>
           <Container>
-            <StyledImageUploadInput type="account" atomtype="profileImage" initialImageUrl={profileImageUrl} />
+            <StyledImageUploadInput type="account" atomtype="profileImage" initialImageUrl={userProfileImageUrl} />
             <InputWrapper>
               <Controller control={control} name="email" render={({ field }) => <StyledInput label="이메일" {...field} disabled />} />
               <Controller

--- a/components/Modal/KebabModal.tsx
+++ b/components/Modal/KebabModal.tsx
@@ -112,8 +112,6 @@ const Wrapper = styled.div`
   background: var(--Grayfa);
   box-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
 
-  z-index: ${Z_INDEX.KebabModal_Wrapper};
-
   @media screen and (max-width: ${DeviceSize.mobile}) {
     width: 8.6rem;
     height: 7.4rem;

--- a/components/Modal/ModalInput/ImageUploadInput.tsx
+++ b/components/Modal/ModalInput/ImageUploadInput.tsx
@@ -3,7 +3,7 @@ import EditIcon from "@/assets/icons/edit.svg";
 import { cardImageAtom, profileImageAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
-import { ChangeEvent, Dispatch, SetStateAction, useState } from "react";
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from "react";
 import styled, { css } from "styled-components";
 
 interface ImageUploadInputProps {
@@ -25,6 +25,10 @@ const ImageUploadInput = ({ type, className, initialImageUrl, handleDeleteClick,
       setPreviewUrl(URL.createObjectURL(file));
     }
   };
+
+  useEffect(() => {
+    setPreviewUrl(initialImageUrl as string | null);
+  }, [initialImageUrl]);
 
   return (
     <InputBox>

--- a/components/common/Nav/Profile.tsx
+++ b/components/common/Nav/Profile.tsx
@@ -2,7 +2,7 @@ import { getUsers } from "@/api/users";
 import { UserData } from "@/api/users/users.types";
 import ArrowIcon from "@/assets/icons/arrow-drop-down.svg";
 import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
-import { activeDropdownAtom } from "@/states/atoms";
+import { activeDropdownAtom, userDataAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { Z_INDEX } from "@/styles/ZindexStyles";
 import { useAtom } from "jotai";
@@ -13,8 +13,8 @@ import styled from "styled-components";
 
 const Profile = () => {
   const router = useRouter();
-  const [user, setUser] = useState<UserData>();
   const [activeDropdown, setActiveDropdown] = useAtom(activeDropdownAtom);
+  const [userData, setUserData] = useAtom(userDataAtom);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const path = router.pathname;
 
@@ -29,37 +29,33 @@ const Profile = () => {
   };
 
   useEffect(() => {
-    const loadUserData = async () => {
-      const res = await getUsers({ token: localStorage.getItem("accessToken") });
-      if (res !== null) setUser({ ...res });
-    };
-
-    loadUserData();
-
-    const closeMenu = (event: Event) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setActiveDropdown(null);
+    const fetchUserData = async () => {
+      const token = localStorage.getItem("accessToken");
+      if (token) {
+        const res = await getUsers({ token });
+        if (res) {
+          setUserData(res);
+        }
       }
     };
 
-    document.addEventListener("click", closeMenu);
-    return () => {
-      document.removeEventListener("click", closeMenu);
-    };
-  }, []);
+    if (!userData) {
+      fetchUserData();
+    }
+  }, [userData, setUserData]);
 
   return (
     <>
-      {user && (
+      {userData && (
         <Wrapper onClick={toggleKebabMenu} ref={dropdownRef}>
-          {user.profileImageUrl ? (
-            <ProfileIcon $image={user.profileImageUrl} />
+          {userData.profileImageUrl ? (
+            <ProfileIcon $image={userData.profileImageUrl} />
           ) : (
             <NoProfileImageWrapper>
-              <NoProfileImage id={user.id} nickname={user.nickname} isBorder={true} />
+              <NoProfileImage id={userData.id} nickname={userData.nickname} isBorder={true} />
             </NoProfileImageWrapper>
           )}
-          <Name>{user?.nickname}</Name>
+          <Name>{userData.nickname}</Name>
           <StyledArrowIcon $active={activeDropdown === "profile"} onClick={toggleKebabMenu} />
           {activeDropdown === "profile" && (
             <DropdownMenu>

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -3,6 +3,7 @@ import { Invitation } from "@/api/invitations/invitations.types";
 import { DASHBOARD_COLOR } from "@/constants/ColorConstant";
 import { Columns } from "@/api/columns/columns.types";
 import { Card } from "@/api/cards/cards.types";
+import { UserData } from "@/api/users/users.types";
 
 // 현재 활성화된 드롭다운의 식별자를 저장하는 아톰
 export const activeDropdownAtom = atom<string | null>(null);
@@ -56,3 +57,5 @@ export const statusAtom = atom("로딩 중");
 export const selectedIdAtom = atom<number | null>(null);
 
 export const userProfileImageUrlAtom = atom<string>("");
+
+export const userDataAtom = atom<UserData | null>(null);

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -54,3 +54,5 @@ export const isOpenAtom = atom(false);
 export const statusAtom = atom("로딩 중");
 
 export const selectedIdAtom = atom<number | null>(null);
+
+export const profileImageUrlAtom = atom<string>("");

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -55,4 +55,4 @@ export const statusAtom = atom("로딩 중");
 
 export const selectedIdAtom = atom<number | null>(null);
 
-export const profileImageUrlAtom = atom<string>("");
+export const userProfileImageUrlAtom = atom<string>("");

--- a/styles/ZindexStyles.ts
+++ b/styles/ZindexStyles.ts
@@ -11,7 +11,6 @@ export const Z_INDEX = {
   Column_ButtonWrapper: 1,
   MyDashboardList_ModalBackdrop: 10,
   TaskModal_StyledKebabModal: 1500,
-  KebabModal_Wrapper: 1500,
   ContactDropdown_List: 1500,
   StateDropdown_List: 1500,
 };


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- 프로필 이미지 혹은 닉네임 변경시 데이터 연동 (둘 중 하나만 수정하거나, 둘 다 수정할 경우에 따라 로직 구현)
- 프로필 이미지 기존에 있을 경우 프리뷰로 보여주기 적용
- 프로필 이미지 삭제할 경우 유저 데이터에 null 반영
- Jotai로 유저 데이터 상태 관리, 어카운트 프로필에서 수정시 반영 & 상단 Nav 프로필 영역에 바로 변경사항 반영 적용

***

## 📷 ScreenShot
화면 녹화 아직 못했... 좀 이따 올릴게용
---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
