### PR TITLE
🍀 refactor: 기타 기능들 수정

### DIFF
--- a/components/Dashboard/Column/Column.tsx
+++ b/components/Dashboard/Column/Column.tsx
@@ -105,11 +105,11 @@ const Column = ({ columnId, title }: ColumnProps) => {
 export default Column;
 
 const Wrapper = styled.div`
+  min-width: fit-content;
+  height: calc(100vh - 7rem);
+
   padding: 2rem;
   border-right: 1px solid var(--Grayd9);
-
-  min-width: fit-content;
-  height: 100vh;
 
   overflow: hidden;
 
@@ -117,7 +117,15 @@ const Wrapper = styled.div`
   flex-direction: column;
 
   @media (max-width: ${DeviceSize.tablet}) {
+    width: 35.5rem;
+    height: 100%;
+    max-height: 50rem;
+
     border-bottom: 1px solid var(--Grayd9);
+  }
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 30.8rem;
   }
 
   &.show-scrollbar {
@@ -129,7 +137,7 @@ const Wrapper = styled.div`
   }
 
   &::-webkit-scrollbar-thumb {
-    background-color: #8db877;
+    background-color: var(--ScrollBar);
     border-radius: 5rem;
   }
 `;

--- a/components/Dashboard/Column/ColumnHeader.tsx
+++ b/components/Dashboard/Column/ColumnHeader.tsx
@@ -4,6 +4,7 @@ import CounterCard from "@/components/common/Chip/CounterCard";
 import styled from "styled-components";
 import KebabModal from "@/components/Modal/KebabModal";
 import { useRef, useEffect, useState } from "react";
+import { DeviceSize } from "@/styles/DeviceSize";
 
 interface ColumnHeaderProps {
   title: string;
@@ -65,6 +66,10 @@ const Content = styled.div`
 const Title = styled.div`
   font-size: 1.8rem;
   font-weight: 700;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    font-size: 1.6rem;
+  }
 `;
 
 const StyledCircleIcon = styled(CircleIcon)`

--- a/components/Dashboard/Column/Columns.tsx
+++ b/components/Dashboard/Column/Columns.tsx
@@ -28,6 +28,7 @@ const Columns = () => {
 
   const rules = {
     required: "생성할 이름을 입력해주세요",
+    maxLength: { value: 15, message: "컬럼 이름은 15자를 초과할 수 없습니다." },
     validate: (v: string) => {
       if (isTitleExist(v)) return "이름이 중복되었습니다. 다시 입력해주세요!";
     },
@@ -35,11 +36,6 @@ const Columns = () => {
 
   const handleOnSubmit = async (data: FormData) => {
     const res = await postColumns({ title: data.inputData, dashboardId: Number(boardid), token: localStorage.getItem("accessToken") });
-
-    // if (totalColumns >= 10) {
-    //   toast("칼럼의 개수는 10개를 초과할 수 없습니다.");
-    //   setToastVisible((prev) => !prev);
-    // }
 
     if (res == null) {
       toast("칼럼 생성에 실패했습니다.");
@@ -55,7 +51,7 @@ const Columns = () => {
 
   const handleAddColumn = () => {
     if (totalColumns >= 10) {
-      toast("칼럼의 개수는 10개를 초과할 수 없습니다.");
+      toast("컬럼의 개수는 10개를 초과할 수 없습니다.");
       setToastVisible((prev) => !prev);
     } else {
       openModalFunc();

--- a/components/Dashboard/Column/Columns.tsx
+++ b/components/Dashboard/Column/Columns.tsx
@@ -103,16 +103,16 @@ const Columns = () => {
 export default Columns;
 
 const Wrapper = styled.div`
-  height: 100vh;
   margin-left: 30rem;
 
   display: flex;
 
   @media (max-width: ${DeviceSize.tablet}) {
+    width: 58.5rem;
+
     margin-left: 16rem;
 
     flex-direction: column;
-    width: auto;
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
@@ -122,17 +122,27 @@ const Wrapper = styled.div`
 `;
 
 const ButtonWrapper = styled.div`
-  width: 100%;
-  height: 11rem;
+  min-width: fit-content;
+  height: calc(100vh - 7rem);
 
-  margin-top: 6.3rem;
-  margin-left: 2rem;
+  padding: 2rem;
 
-  z-index: ${Z_INDEX.Column_ButtonWrapper};
+  border-right: 1px solid var(--Grayd9);
+
+  display: flex;
+  flex-direction: column;
+
+  overflow: hidden;
 
   @media (max-width: ${DeviceSize.tablet}) {
-    position: sticky;
-    bottom: 0;
+    width: 35.5rem;
+    height: 100%;
+
+    border-bottom: 1px solid var(--Grayd9);
+  }
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    width: 30.8rem;
   }
 `;
 

--- a/components/Modal/KebabModal.tsx
+++ b/components/Modal/KebabModal.tsx
@@ -29,6 +29,7 @@ const KebabModal = ({ columnId, setIsClicked, handleClick }: KebabModalProps) =>
 
   const rules = {
     required: "변경할 이름을 입력해주세요",
+    maxLength: { value: 15, message: "컬럼 이름은 15자를 초과할 수 없습니다." },
     validate: (v: string) => {
       if (isTitleExist(v)) return "이름이 중복되었습니다. 다시 입력해주세요!";
     },
@@ -80,7 +81,7 @@ const KebabModal = ({ columnId, setIsClicked, handleClick }: KebabModalProps) =>
       </Wrapper>
       {isEditModalOpen && (
         <ModalWrapper>
-          <ModalContainer title="컬럼 관리" label="컬럼 이름" buttonType="변경" onClose={closeEditModalFunc} onSubmit={handleChangeColumnName} rules={rules} />
+          <ModalContainer title="컬럼 이름 수정" label="수정할 컬럼 이름" buttonType="변경" onClose={closeEditModalFunc} onSubmit={handleChangeColumnName} rules={rules} />
         </ModalWrapper>
       )}
       {isDeleteModalOpen && (

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -78,6 +78,16 @@ const MyDashboardList = () => {
 
   return (
     <Wrapper>
+      <PageContent>
+        {totalPageCount} 페이지 중 {currentPage}{" "}
+        <ButtonSet
+          type="forwardAndBackward"
+          isLeftDisabled={currentPage === 1}
+          isRightDisabled={currentPage === totalPageCount}
+          onClickLeft={() => handlePageChange(-1)}
+          onClickRight={() => handlePageChange(1)}
+        />
+      </PageContent>
       <Container>
         <Button
           type="newDashboard"
@@ -96,16 +106,6 @@ const MyDashboardList = () => {
             );
           })}
       </Container>
-      <PageContent>
-        {totalPageCount} 페이지 중 {currentPage}{" "}
-        <ButtonSet
-          type="forwardAndBackward"
-          isLeftDisabled={currentPage === 1}
-          isRightDisabled={currentPage === totalPageCount}
-          onClickLeft={() => handlePageChange(-1)}
-          onClickRight={() => handlePageChange(1)}
-        />
-      </PageContent>
       {isModalOpen && (
         <ModalWrapper>
           <ModalContainer title="새로운 대시보드" label="대시보드 이름" buttonType="생성" onClose={closeModalFunc} onSubmit={handleAddModal} rules={rules} />
@@ -117,21 +117,16 @@ const MyDashboardList = () => {
 
 export default MyDashboardList;
 
-const Container = styled.div`
-  width: fit-content;
-  display: grid;
-  grid-template-columns: repeat(3, 33.2rem);
-  grid-template-rows: repeat(2, 7.15rem);
-  gap: 1.2rem;
+const Wrapper = styled.div`
+  max-width: 102rem;
 
-  @media (max-width: ${DeviceSize.tablet}) {
-    grid-template-columns: repeat(2, 24.7rem);
-    grid-template-rows: repeat(3, 6.955rem);
-  }
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  align-items: end;
 
   @media (max-width: ${DeviceSize.mobile}) {
-    grid-template-columns: repeat(1, 26rem);
-    grid-template-rows: repeat(6, 6.56rem);
+    max-width: 40rem;
   }
 `;
 
@@ -143,11 +138,21 @@ const PageContent = styled.div`
   font-size: 1.4rem;
 `;
 
-const Wrapper = styled.div`
-  width: fit-content;
+const Container = styled.div`
+  width: 100%;
 
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(2, 7.15rem);
   gap: 1.2rem;
-  align-items: end;
+
+  @media (max-width: ${DeviceSize.tablet}) {
+    grid-template-columns: repeat(2, 2fr);
+    grid-template-rows: repeat(3, 6.955rem);
+  }
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    grid-template-columns: repeat(1, 1fr);
+    grid-template-rows: repeat(6, 6.56rem);
+  }
 `;

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -79,7 +79,7 @@ const MyDashboardList = () => {
   return (
     <Wrapper>
       <PageContent>
-        {totalPageCount} 페이지 중 {currentPage}{" "}
+        {totalPageCount} 페이지 중 {currentPage}
         <ButtonSet
           type="forwardAndBackward"
           isLeftDisabled={currentPage === 1}
@@ -142,12 +142,13 @@ const Container = styled.div`
   width: 100%;
 
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-template-rows: repeat(2, 7.15rem);
   gap: 1.2rem;
 
   @media (max-width: ${DeviceSize.tablet}) {
-    grid-template-columns: repeat(2, 2fr);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-rows: repeat(3, 6.955rem);
   }
 

--- a/components/Table/InvitedDashboard.tsx
+++ b/components/Table/InvitedDashboard.tsx
@@ -101,7 +101,7 @@ const InvitedDashboard = () => {
 export default InvitedDashboard;
 
 const Container = styled.div`
-  width: 102rem;
+  max-width: 102rem;
   height: 60rem;
   padding: 3rem;
   border-radius: 8px;
@@ -112,14 +112,10 @@ const Container = styled.div`
 
   background: var(--White);
 
-  @media screen and (max-width: ${DeviceSize.tablet}) {
-    width: 50.4rem;
-  }
-
   @media screen and (max-width: ${DeviceSize.mobile}) {
-    width: 26rem;
+    max-width: 40rem;
 
-    padding: 1.6rem;
+    padding: 2.4rem 1.6rem;
   }
 `;
 

--- a/components/Table/NoInvite.tsx
+++ b/components/Table/NoInvite.tsx
@@ -28,12 +28,8 @@ const Container = styled.div`
 
   background: var(--White);
 
-  @media screen and (max-width: ${DeviceSize.tablet}) {
-    width: 50.4rem;
-  }
-
   @media screen and (max-width: ${DeviceSize.mobile}) {
-    width: 26rem;
+    max-width: 40rem;
 
     padding: 2.4rem 1.6rem;
   }
@@ -54,6 +50,10 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  @media screen and (max-width: ${DeviceSize.mobile}) {
+    margin-top: 12em;
+  }
 `;
 
 const NoInviteImg = styled.img.attrs({

--- a/components/common/Buttons/Button.tsx
+++ b/components/common/Buttons/Button.tsx
@@ -101,6 +101,7 @@ const StyledTitleWrapper = styled.div`
 
 const StyledDashboardTitle = styled.span`
   width: 85%;
+  /* max-width: 10.5rem; */
   height: 1.8rem;
 
   display: block;

--- a/components/common/Buttons/ButtonStyles.ts
+++ b/components/common/Buttons/ButtonStyles.ts
@@ -48,8 +48,11 @@ const TYPES = {
       font-size: 1.2rem;
     }
   `,
+
   addNewColumn: css`
     width: 35.4rem;
+
+    margin-top: 4.3rem;
 
     padding: 2.45rem 0;
 
@@ -65,6 +68,8 @@ const TYPES = {
 
     @media (max-width: ${DeviceSize.tablet}) {
       width: 54.4rem;
+
+      margin-top: 0;
 
       padding: 2.45rem 0;
 

--- a/components/common/Buttons/ButtonStyles.ts
+++ b/components/common/Buttons/ButtonStyles.ts
@@ -127,8 +127,9 @@ const TYPES = {
       font-size: 1.6rem;
     }
   `,
+
   newDashboard: css`
-    width: 33.2rem;
+    width: 100%;
 
     padding: 2.4rem 0;
 
@@ -137,15 +138,7 @@ const TYPES = {
     font-size: 1.6rem;
     font-weight: 600;
 
-    /* 디자인은 추후 변경 */
-    &:disabled {
-      /* color: var(--Grayfa); */
-      cursor: default;
-    }
-
     @media (max-width: ${DeviceSize.tablet}) {
-      width: 24.7rem;
-
       padding: 2.3rem 0;
 
       gap: 1.2rem;
@@ -155,8 +148,6 @@ const TYPES = {
     }
 
     @media (max-width: ${DeviceSize.mobile}) {
-      width: 26rem;
-
       padding: 1.9rem 0;
 
       gap: 1.2rem;
@@ -167,7 +158,7 @@ const TYPES = {
   `,
 
   dashboardList: css`
-    width: 33.2rem;
+    width: 100%;
 
     padding: 2.55rem 2rem;
 
@@ -177,8 +168,6 @@ const TYPES = {
     font-weight: 600;
 
     @media (max-width: ${DeviceSize.tablet}) {
-      width: 24.7rem;
-
       padding: 2.45rem 2rem;
 
       justify-content: space-between;
@@ -188,8 +177,6 @@ const TYPES = {
     }
 
     @media (max-width: ${DeviceSize.mobile}) {
-      width: 26rem;
-
       padding: 2rem 2rem;
 
       justify-content: space-between;

--- a/components/common/Nav/NavContainer.tsx
+++ b/components/common/Nav/NavContainer.tsx
@@ -75,6 +75,10 @@ const Title = styled.div`
     overflow: auto;
   }
 
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
   @media (max-width: ${DeviceSize.mobile}) {
     font-size: 1.8rem;
   }

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -166,7 +166,7 @@ export default SideMenu;
 
 const Wrapper = styled.div`
   width: 30rem;
-  height: 155rem;
+  height: 100vh;
 
   padding: 2rem 1.2rem;
 
@@ -186,12 +186,10 @@ const Wrapper = styled.div`
 
   @media (max-width: ${DeviceSize.tablet}) {
     width: 16rem;
-    height: 166.6rem;
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
     width: 6.7rem;
-    height: 185.9rem;
   }
 `;
 

--- a/constants/InputConstant.ts
+++ b/constants/InputConstant.ts
@@ -24,7 +24,7 @@ export const ERROR_MESSAGE = {
   confirmPasswordCheck: "비밀번호가 일치하지 않습니다.",
 
   nicknameRequired: "닉네임을 입력해 주세요.",
-  nicknameInvalid: "10자 이하로 작성해 주세요.",
+  nicknameInvalid: "닉네임은 10자를 초과할 수 없습니다.",
 
   currentPasswordRequired: "현재 비밀번호를 입력해 주세요.",
   currentPasswordDifferent: "현재 비밀번호와 다릅니다. 다시 입력해주세요.",

--- a/pages/dashboard/[boardid]/edit.tsx
+++ b/pages/dashboard/[boardid]/edit.tsx
@@ -76,7 +76,7 @@ const DashboardEditPage = () => {
 export default DashboardEditPage;
 
 const Wrapper = styled.div`
-  height: 145.3rem;
+  height: 100vh;
 
   background-color: var(--MainLight);
 `;

--- a/pages/dashboard/[boardid]/index.tsx
+++ b/pages/dashboard/[boardid]/index.tsx
@@ -3,6 +3,7 @@ import { GetDashboardListData } from "@/api/dashboards/dashboards.types";
 import Columns from "@/components/Dashboard/Column/Columns";
 import DashboardNav from "@/components/common/Nav/DashboardNav";
 import SideMenu from "@/components/common/SideMenu/SideMenu";
+import { DeviceSize } from "@/styles/DeviceSize";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { styled } from "styled-components";
@@ -44,7 +45,17 @@ export default DashBoardPage;
 
 const ColumnWrapper = styled.div`
   width: 100%;
+  height: calc(100vh - 7rem);
+
   overflow: scroll;
 
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
   background-color: var(--Grayfa);
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    height: calc(100vh - 6rem);
+  }
 `;

--- a/styles/ColorStyles.ts
+++ b/styles/ColorStyles.ts
@@ -32,4 +32,5 @@ export const MAIN = css`
   --MainLight: #faf6f0;
   --MainBG: #eef2e6;
   --MainHover: #dce6d1;
+  --ScrollBar: #8db877;
 `;


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
### mydashboard
- [x]  반응형 수정
- [x]  초대받은 대시보드의 페이지네이션 버튼이 반응형에 따라 줄어들도록 수정
- [x]  페이지네이션 버튼을 오른쪽 상단으로 위치 옮기기
- [x]  [모바일, 태블릿] 새로운 대시보드 버튼, 아래에 있는 대시보드 목록들 버튼의 영역을 width: 100%로 수정
- [x]  초대받은 대시보드 width 100%로 해서 반응형에 따라 자연스럽게 크기 줄어들도록 수정
- [x]  [모바일] 회색로고: margin-top: 12rem;
- [x]  컬럼 이름 글자수 15글자로 제한
- [x]  컬럼 이름이 길어지는 만큼 컬럼의 너비가 늘어나는 문제 ⇒ 컬럼 글자수 15자로 제한해서 해결

### dashboard/id
- [x]  버튼 영역을 width:100%로 해서 컬럼 너비에 꽉 차 보이게 수정
- [x]  하단에 가로 스크롤 표시되는 것 안 보이게 하기

### etc
- 그 외 자잘한 것들 수정
***

## 📷 ScreenShot
---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
