### PR TITLE
🍀 refactor: 상태와 담당자 드롭다운 리팩토링

### DIFF
--- a/components/Modal/ModalInput/DropdownList.tsx
+++ b/components/Modal/ModalInput/DropdownList.tsx
@@ -1,8 +1,9 @@
 import { Columns } from "@/api/columns/columns.types";
 import CheckIcon from "@/assets/icons/check.svg";
 import ColumnName from "@/components/common/Chip/ColumnName";
+import { Z_INDEX } from "@/styles/ZindexStyles";
 import { SetStateAction } from "jotai";
-import { Dispatch, useState } from "react";
+import { Dispatch, forwardRef } from "react";
 import styled from "styled-components";
 
 interface DropDownMenuProps {
@@ -24,11 +25,9 @@ const DropdownList = ({ $isOpen, setStatus, columnData, selectedId, onColumnSele
       <DropdownContent>
         <ColumnWrapper>
           {columnData.map((column) => (
-            <ButtonWraper key={column.id}>
-              {selectedId === column.id && <StyledCheckIcon alt="Check Icon" />}
-              <Button onClick={() => handleSelected(column.id, column.title)}>
-                <ColumnName status={column.title} />
-              </Button>
+            <ButtonWraper key={column.id} onClick={() => handleSelected(column.id, column.title)}>
+              <ColumnName status={column.title} />
+              <StyledCheckIcon alt="Check Icon" />
             </ButtonWraper>
           ))}
         </ColumnWrapper>
@@ -45,9 +44,6 @@ const Wrapper = styled.div<{ $isOpen: boolean }>`
 
 const DropdownContent = styled.div`
   width: 21.7rem;
-  height: 11.8rem;
-
-  padding: 1.3rem 0.8rem;
 
   border-radius: 0.6rem;
   border: 1px solid var(--Grayd9);
@@ -55,30 +51,41 @@ const DropdownContent = styled.div`
   box-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
 
   position: relative;
+
+  z-index: ${Z_INDEX.DropdownList_Wrapper};
 `;
 
 const ColumnWrapper = styled.div`
-  width: 12.2rem;
-  height: 9.2rem;
-
   display: flex;
   flex-direction: column;
-  gap: 1.3rem;
+`;
+
+const ButtonWraper = styled.li`
+  height: 4.5rem;
+
+  padding: 0.5rem 1rem;
+
+  display: flex;
+  align-items: center;
+  position: relative;
+
+  cursor: pointer;
+  &:hover {
+    background: var(--Grayfa);
+  }
 `;
 
 const StyledCheckIcon = styled(CheckIcon)`
-  width: 2.2rem;
-  height: 2.2rem;
+  display: none;
 
   position: absolute;
-`;
+  right: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
 
-const ButtonWraper = styled.div`
-  display: flex;
-  align-items: flex-end;
-  gap: 0.6rem;
-`;
+  color: var(--Gray78);
 
-const Button = styled.button`
-  margin-left: 2.8rem;
+  ${ButtonWraper}:hover & {
+    display: block;
+  }
 `;

--- a/styles/ZindexStyles.ts
+++ b/styles/ZindexStyles.ts
@@ -14,4 +14,5 @@ export const Z_INDEX = {
   ContactDropdown_List: 1500,
   StateDropdown_List: 1500,
   MemberListDropdown_Dropdown: 2000,
+  DropdownList_Wrapper: 1,
 };


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- [x]  담당자드롭다운과 상태드롭다운을 담당자 드롭다운의 디자인으로 통일 
- [x]  담당자드롭다운 상태드롭다운 화살표 변환 
- [x]  담당자드롭다운 리스트 나올 시 보더 색 상태 드롭다운이랑 같게 만들기
- [x]  담당자 드롭다운, 상태 드롭다운 밖 영역 클릭 시 리스트 닫히게
- [x] 하나의 드롭다운만 열리도록
***

## 📷 ScreenShot
---

https://github.com/SWCF-8TEAM/taskify/assets/72639353/f19340f5-e722-4b46-8303-96e596d76faf



## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
