### PR TITLE
🛠️  fix: 이전 대시보드가 다른 대시보드에서 깜빡이는 현상

### DIFF
--- a/components/Dashboard/Column/ColumnHeader.tsx
+++ b/components/Dashboard/Column/ColumnHeader.tsx
@@ -13,17 +13,17 @@ interface ColumnHeaderProps {
 }
 
 const ColumnHeader = ({ title, count, columnId }: ColumnHeaderProps) => {
-  const [isClicked, setIsClicked] = useState(false);
+  const [isKebabOpen, setIsKebabOpen] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
 
   const handleClick = () => {
-    setIsClicked((prev) => !prev);
+    setIsKebabOpen((prev) => !prev);
   };
 
   useEffect(() => {
     const handleOutsideClick = (event: Event) => {
       if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
-        setIsClicked(false);
+        setIsKebabOpen(false);
       }
     };
 
@@ -42,7 +42,7 @@ const ColumnHeader = ({ title, count, columnId }: ColumnHeaderProps) => {
       </Content>
       <Div ref={modalRef}>
         <SettingIcon onClick={handleClick} style={{ cursor: "pointer" }} />
-        {isClicked && <KebabModal columnId={columnId} setIsClicked={setIsClicked} />}
+        {isKebabOpen && <KebabModal columnId={columnId} setIsKebabOpen={setIsKebabOpen} />}
       </Div>
     </Wrapper>
   );

--- a/components/Dashboard/Column/Columns.tsx
+++ b/components/Dashboard/Column/Columns.tsx
@@ -74,7 +74,7 @@ const Columns = () => {
         }
       }
     };
-    loadColumnsData();
+    if (boardid) loadColumnsData();
   }, [boardid]);
 
   return (

--- a/components/Modal/KebabModal.tsx
+++ b/components/Modal/KebabModal.tsx
@@ -12,11 +12,11 @@ import ModalContainer, { FormData } from "./ModalContainer";
 
 interface KebabModalProps {
   columnId: number;
-  setIsClicked: Dispatch<SetStateAction<boolean>>;
+  setIsKebabOpen: Dispatch<SetStateAction<boolean>>;
   handleClick?: () => void;
 }
 
-const KebabModal = ({ columnId, setIsClicked, handleClick }: KebabModalProps) => {
+const KebabModal = ({ columnId, setIsKebabOpen, handleClick }: KebabModalProps) => {
   const [columns, setColumns] = useAtom(columnsAtom);
   const [totalColumns, setTotalColumns] = useAtom(totalColumnsAtom);
   const { isModalOpen: isDeleteModalOpen, openModalFunc: openDeleteModalFunc, closeModalFunc: closeDeleteModalFunc } = useModal();
@@ -45,6 +45,7 @@ const KebabModal = ({ columnId, setIsClicked, handleClick }: KebabModalProps) =>
 
     setColumns(columns.map((v) => (v.id == columnId ? res : v)));
     closeEditModalFunc();
+    setIsKebabOpen(false);
   };
 
   const handleDeleteColumn = async () => {
@@ -74,7 +75,7 @@ const KebabModal = ({ columnId, setIsClicked, handleClick }: KebabModalProps) =>
   return (
     <>
       <Wrapper>
-        <KebabListWrapper onBlur={() => setIsClicked} tabIndex={0}>
+        <KebabListWrapper>
           <KebabList onClick={openEditModalFunc}>수정하기</KebabList>
           <KebabList onClick={openDeleteModalFunc}>삭제하기</KebabList>
         </KebabListWrapper>

--- a/components/Modal/ModalInput/ModalInput.tsx
+++ b/components/Modal/ModalInput/ModalInput.tsx
@@ -190,6 +190,9 @@ const InputArea = styled.div<InputAreaProps>`
 const StyledTextArea = styled.textarea<InputAreaProps>`
   border: none;
 
+  height: 100%;
+  width: 100%;
+
   flex-grow: 1;
   resize: none;
 

--- a/components/Modal/TaskModal/Comments.tsx
+++ b/components/Modal/TaskModal/Comments.tsx
@@ -219,8 +219,11 @@ const CommentItem = styled.div`
   flex-direction: row;
 
   margin-bottom: 0.8rem;
+  padding: 1rem 0;
 
   font-size: 1.4rem;
+
+  border-bottom: 1px solid var(--Grayee);
 
   @media (max-width: ${DeviceSize.mobile}) {
     font-size: 1.2rem;

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -39,6 +39,7 @@ const MyDashboardList = () => {
 
   const rules = {
     required: "생성할 이름을 입력해주세요",
+    maxLength: { value: 15, message: "대시보드 이름은 15자를 초과할 수 없습니다." },
     validate: (v: string) => {
       if (isTitleExist(v)) return "이름이 중복되었습니다. 다시 입력해주세요!";
     },
@@ -53,7 +54,7 @@ const MyDashboardList = () => {
       closeModalFunc();
       return;
     }
-    currentPage === 1 ? setDashboards(() => [res, ...dashboards.slice(0, dashboards.length - 1)]) : setCurrentPage(1);
+    currentPage === 1 ? loadDashboardList() : setCurrentPage(1);
 
     closeModalFunc();
   };
@@ -68,7 +69,7 @@ const MyDashboardList = () => {
 
     if (res !== null) {
       setDashboards([...res.dashboards]);
-      setTotalPageCount(Math.ceil(res.totalCount / PAGE_SIZE));
+      setTotalPageCount(Math.max(Math.ceil(res.totalCount / PAGE_SIZE), 1));
     }
   };
 

--- a/components/common/Nav/DashboardNav.tsx
+++ b/components/common/Nav/DashboardNav.tsx
@@ -17,7 +17,7 @@ const DashboardNav = () => {
       const res = await getDashboard({ dashboardId: String(boardid), token: localStorage.getItem("accessToken") });
       if (res !== null) setDashboard(res);
     };
-    loadDashboardData();
+    if (boardid) loadDashboardData();
   }, [boardid, editDashboards]);
 
   return <>{dashboard && <NavContainer title={dashboard.title} $isDashboard={true} createdByMe={dashboard.createdByMe} />}</>;

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -7,11 +7,15 @@ import { styled } from "styled-components";
 import { Z_INDEX } from "@/styles/ZindexStyles";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
+import { useAtom } from "jotai";
+import { columnsAtom } from "@/states/atoms";
 
 const MyDashboard = () => {
   const router = useRouter();
+  const [columns, setColumns] = useAtom(columnsAtom); //이전의 column들 초기화, 대시보드에 접근하려면 이곳을 거치므로 여기서 초기화
 
   useEffect(() => {
+    setColumns([]);
     const token = localStorage.getItem("accessToken");
 
     if (!token) {


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description

- [x]  할일 생성의 설명 인풋란 width: 100% height:100%(지은)
- [x]  댓글의 인풋란 height:100% 되어있더라구요(지은)
- [x]  댓글 사이사이 border-bottom (지은)
- [x] 대시보드 클릭시 이전정보 노출되는 문제 수정 (조타이가 가진 대시보드 정보 초기화) (지은)
- [x] 대시보드 리스트에 아무것도 없어도 페이지네이션버튼 0페이지중1로 표시되는 문제 (지은)
- [x] 에러 수정
<img width="1440" alt="스크린샷 2024-01-04 오후 2 59 39" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/8b93e446-c187-45d0-80f0-4d7d9da86ffa">

***

## 📷 ScreenShot
---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
