### PR TITLE
🍀 refactor: 전반적으로 페이지 수정

### DIFF
--- a/components/Account/AccountProfile.tsx
+++ b/components/Account/AccountProfile.tsx
@@ -156,6 +156,8 @@ const StyledForm = styled.form`
 `;
 
 const Container = styled.div`
+  width: 100%;
+
   display: flex;
   justify-content: space-between;
   gap: 1.6rem;
@@ -171,7 +173,7 @@ const StyledImageUploadInput = styled(ImageUploadInput)`
 `;
 
 const InputWrapper = styled.div`
-  width: 36.6rem;
+  width: 100%;
 
   display: flex;
   flex-direction: column;
@@ -179,15 +181,7 @@ const InputWrapper = styled.div`
 `;
 
 const StyledInput = styled(Input)`
-  width: 36.6rem;
-
-  @media (max-width: ${DeviceSize.tablet}) {
-    width: 29rem;
-  }
-
-  @media (max-width: ${DeviceSize.mobile}) {
-    width: 24.4rem;
-  }
+  width: 100%;
 `;
 
 const SaveButton = styled.button`

--- a/components/Dashboard/Card/Card.tsx
+++ b/components/Dashboard/Card/Card.tsx
@@ -143,8 +143,16 @@ const Title = styled.div<{ $imageurl: string }>`
 `;
 
 const Tags = styled.div`
+  max-width: 27.4rem;
+
   display: flex;
   gap: 0.6rem;
+
+  overflow-x: hidden;
+
+  &:hover {
+    overflow-x: auto;
+  }
 
   @media (max-width: ${DeviceSize.tablet}) {
     height: 50%;

--- a/components/Dashboard/Column/Column.tsx
+++ b/components/Dashboard/Column/Column.tsx
@@ -131,15 +131,6 @@ const Wrapper = styled.div`
   &.show-scrollbar {
     overflow-y: auto;
   }
-
-  &::-webkit-scrollbar {
-    width: 0.2rem;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background-color: var(--ScrollBar);
-    border-radius: 5rem;
-  }
 `;
 
 const Container = styled.div`

--- a/components/Landing/MainSection.tsx
+++ b/components/Landing/MainSection.tsx
@@ -33,6 +33,10 @@ const Container = styled.div`
   align-items: center;
 
   background-color: var(--MainLight);
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    top: 6rem;
+  }
 `;
 
 const MainImage = styled(Image)`

--- a/components/Landing/MainSection.tsx
+++ b/components/Landing/MainSection.tsx
@@ -25,6 +25,9 @@ export default MainSection;
 const Container = styled.div`
   padding: 9.4rem 0;
 
+  position: relative;
+  top: 7rem;
+
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/components/Modal/AddTaskModal.tsx
+++ b/components/Modal/AddTaskModal.tsx
@@ -10,8 +10,8 @@ import { useAtom } from "jotai";
 import { useRouter } from "next/router";
 import React, { useRef, useState } from "react";
 import styled from "styled-components";
-import ContactDropdown from "./ModalInput/ContactDropdown";
-import ImageUploadInput from "./ModalInput/ImageUploadInput";
+import ContactDropdown from "@/components/Modal/ModalInput/ContactDropdown";
+import ImageUploadInput from "@/components/Modal/ModalInput/ImageUploadInput";
 
 interface AddTaskModalProps {
   closeModalFunc: () => void;

--- a/components/Modal/EditTaskModal.tsx
+++ b/components/Modal/EditTaskModal.tsx
@@ -11,7 +11,7 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
-import ModalInput from "./ModalInput/ModalInput";
+import ModalInput from "@/components/Modal/ModalInput/ModalInput";
 
 interface EditTaskModalProps {
   card: Card;

--- a/components/Modal/KebabModal.tsx
+++ b/components/Modal/KebabModal.tsx
@@ -8,7 +8,7 @@ import { Z_INDEX } from "@/styles/ZindexStyles";
 import { useAtom } from "jotai";
 import { Dispatch, SetStateAction, useEffect } from "react";
 import styled from "styled-components";
-import ModalContainer, { FormData } from "./ModalContainer";
+import ModalContainer, { FormData } from "@/components/Modal/ModalContainer";
 
 interface KebabModalProps {
   columnId: number;

--- a/components/Modal/ModalInput/TagInput.tsx
+++ b/components/Modal/ModalInput/TagInput.tsx
@@ -147,15 +147,7 @@ const TagArea = styled.div`
 
   max-width: 100%;
   height: 3rem;
+  
   overflow-x: scroll;
   overflow-y: hidden;
-
-  &::-webkit-scrollbar {
-    height: 0.7rem;
-    border-radius: 0.6rem;
-  }
-  &::-webkit-scrollbar-thumb {
-    background: #a0cb9b;
-    border-radius: 0.6rem;
-  }
 `;

--- a/components/Modal/ModalWrapper.tsx
+++ b/components/Modal/ModalWrapper.tsx
@@ -30,7 +30,7 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: ${Z_INDEX.MyDashboardList_ModalBackdrop};
+  z-index: ${Z_INDEX.ModalWrapper};
 `;
 
 const Container = styled.div`

--- a/components/Modal/TaskModal/Comments.tsx
+++ b/components/Modal/TaskModal/Comments.tsx
@@ -1,6 +1,6 @@
 import { DeviceSize } from "@/styles/DeviceSize";
 import { styled } from "styled-components";
-import ModalInput from "../ModalInput/ModalInput";
+import ModalInput from "@/components/Modal/ModalInput/ModalInput";
 import { ChangeEvent, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { deleteComments, getComments, postComments, putComments } from "@/api/comments";
@@ -8,7 +8,7 @@ import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { Card } from "@/api/cards/cards.types";
 import { Comment } from "@/api/comments/comments.types";
 import { formatUpdatedAt } from "@/utils/FormatDate";
-import NoProfileImage from "../../common/NoProfileImage/ProfileImage";
+import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
 import { useAtom } from "jotai";
 import { commentScrollAtom } from "@/states/atoms";
 

--- a/components/Modal/TaskModal/TaskModal.tsx
+++ b/components/Modal/TaskModal/TaskModal.tsx
@@ -17,8 +17,8 @@ import { useAtom } from "jotai";
 import React, { useEffect, useRef, useState } from "react";
 import { FaArrowUpWideShort } from "react-icons/fa6";
 import styled from "styled-components";
-import NoProfileImage from "../../common/NoProfileImage/ProfileImage";
-import Comments from "./Comments";
+import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
+import Comments from "@/components/Modal/TaskModal/Comments";
 
 const TaskModal: React.FC<{ cardData: Card; columnId: number; closeModalFunc: () => void; columnTitle: string }> = ({ cardData, columnId, closeModalFunc, columnTitle }) => {
   const { isModalOpen: isEditModalOpen, openModalFunc: openEditModal, closeModalFunc: closeEditModal } = useModal();
@@ -327,9 +327,16 @@ const CategoryWrapper = styled.div`
 `;
 
 const Tags = styled.div`
-  display: flex;
+  max-width: 57rem;
 
+  display: flex;
   gap: 0.6rem;
+
+  overflow-x: hidden;
+
+  &:hover {
+    overflow-x: auto;
+  }
 
   @media (max-width: ${DeviceSize.tablet}) {
     height: 50%;

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -153,7 +153,7 @@ const Container = styled.div`
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
-    grid-template-columns: repeat(1, 1fr);
+    grid-template-columns: repeat(1, minmax(0, 1fr));
     grid-template-rows: repeat(6, 6.56rem);
   }
 `;

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -11,7 +11,7 @@ import { useAtom } from "jotai";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { styled } from "styled-components";
-import ModalWrapper from "./Modal/ModalWrapper";
+import ModalWrapper from "@/components/Modal/ModalWrapper";
 
 export interface Dashboards {
   id: number;

--- a/components/Table/EditDashboard.tsx
+++ b/components/Table/EditDashboard.tsx
@@ -119,6 +119,10 @@ const Title = styled.h1`
     text-overflow: clip;
     overflow: auto;
   }
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const Form = styled.form`

--- a/components/Table/InvitedDashboard.tsx
+++ b/components/Table/InvitedDashboard.tsx
@@ -197,9 +197,24 @@ const MobileTableTitle = styled.h3`
 `;
 
 const TableBody = styled.h3`
+  width: 23rem;
+
   color: var(--Black33);
   font-size: 1.6rem;
   font-weight: 400;
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:hover {
+    text-overflow: clip;
+    overflow: auto;
+  }
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   @media screen and (max-width: ${DeviceSize.mobile}) {
     width: 70%;

--- a/components/Table/MemberList.tsx
+++ b/components/Table/MemberList.tsx
@@ -10,7 +10,7 @@ import { DeviceSize } from "@/styles/DeviceSize";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
-import NoProfileImage from "../common/NoProfileImage/ProfileImage";
+import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
 import { getUsers } from "@/api/users";
 import { UserData } from "@/api/users/users.types";
 
@@ -84,12 +84,12 @@ const MembersList = () => {
           <MemberItem key={member.id}>
             <MemberInfo>
               {member.profileImageUrl ? (
-              <Profile $url={member.profileImageUrl} />
-            ) : (
-              <NoProfileImageWrapper>
-                <NoProfileImage id={member.userId} nickname={member.nickname} />
-              </NoProfileImageWrapper>
-            )}
+                <Profile $url={member.profileImageUrl} />
+              ) : (
+                <NoProfileImageWrapper>
+                  <NoProfileImage id={member.userId} nickname={member.nickname} />
+                </NoProfileImageWrapper>
+              )}
               <Name>{member.nickname}</Name>
             </MemberInfo>
             {!member.isOwner && <Button type="delete" children="삭제" onClick={() => handleDeleteButtonClick(member.id)} />}

--- a/components/common/Buttons/BackButton.tsx
+++ b/components/common/Buttons/BackButton.tsx
@@ -15,6 +15,8 @@ const BackButton = ({ href }: { href: string }) => {
 export default BackButton;
 
 const Wrapper = styled(Link)`
+  width: 8rem;
+
   display: flex;
   align-items: center;
   gap: 0.6rem;
@@ -22,6 +24,8 @@ const Wrapper = styled(Link)`
   margin-bottom: 1.2rem;
 
   @media (max-width: ${DeviceSize.mobile}) {
+    width: 7rem;
+
     margin-bottom: 1rem;
   }
 `;

--- a/components/common/Buttons/Button.tsx
+++ b/components/common/Buttons/Button.tsx
@@ -101,7 +101,6 @@ const StyledTitleWrapper = styled.div`
 
 const StyledDashboardTitle = styled.span`
   width: 85%;
-  /* max-width: 10.5rem; */
   height: 1.8rem;
 
   display: block;
@@ -110,4 +109,13 @@ const StyledDashboardTitle = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  &:hover {
+    text-overflow: clip;
+    overflow: auto;
+  }
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 `;

--- a/components/common/Nav/MainNav.tsx
+++ b/components/common/Nav/MainNav.tsx
@@ -1,6 +1,7 @@
 import LogoButton from "@/components/common/Buttons/LogoButton";
 import SignButton from "@/components/common/Nav/SignButton";
 import { DeviceSize } from "@/styles/DeviceSize";
+import { Z_INDEX } from "@/styles/ZindexStyles";
 import styled from "styled-components";
 
 const MainNav = () => {
@@ -22,12 +23,16 @@ const Wrapper = styled.nav`
 
   border-bottom: 1px solid var(--Grayd9);
 
+  position: fixed;
+
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
 
   background-color: var(--MainBG);
+
+  z-index: ${Z_INDEX.Navigation};
 
   @media (max-width: ${DeviceSize.tablet}) {
     padding: 1.6rem 4rem 1.6rem 1.6rem;

--- a/components/common/Nav/MainNav.tsx
+++ b/components/common/Nav/MainNav.tsx
@@ -39,6 +39,8 @@ const Wrapper = styled.nav`
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
+    height: 6rem;
+
     padding: 1.6rem 2.4rem;
   }
 `;

--- a/components/common/Nav/MemberListDropdown.tsx
+++ b/components/common/Nav/MemberListDropdown.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import { DeviceSize } from "@/styles/DeviceSize";
-import NoProfileImage from "../NoProfileImage/ProfileImage";
+import NoProfileImage from "@/components/common/NoProfileImage/ProfileImage";
 import { Member } from "@/api/members/members.types";
 import { Z_INDEX } from "@/styles/ZindexStyles";
 
@@ -34,11 +34,13 @@ const Dropdown = styled.div`
   box-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
 
   position: absolute;
-  top: 8%;
-
-  background-color: white;
+  top: 6rem;
 
   z-index: ${Z_INDEX.MemberListDropdown_Dropdown};
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    top: 5rem;
+  }
 `;
 
 const Item = styled.div`
@@ -113,5 +115,9 @@ const Nickname = styled.div`
   &:hover {
     text-overflow: clip;
     overflow: auto;
+  }
+
+  &::-webkit-scrollbar {
+    display: none;
   }
 `;

--- a/components/common/Nav/NavContainer.tsx
+++ b/components/common/Nav/NavContainer.tsx
@@ -3,6 +3,7 @@ import SettingButton from "@/components/common/Nav/DashboardButtons";
 import Profile from "@/components/common/Nav/Profile";
 import ProfileImages from "@/components/common/Nav/ProfileImages";
 import { DeviceSize } from "@/styles/DeviceSize";
+import { Z_INDEX } from "@/styles/ZindexStyles";
 import styled from "styled-components";
 
 interface NavContainerProps {
@@ -36,6 +37,11 @@ const Wrapper = styled.div`
   padding: 2.3rem 8rem 2.3rem 34rem;
   border-bottom: 1px solid var(--Grayd9);
 
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -43,6 +49,8 @@ const Wrapper = styled.div`
   gap: 4rem;
 
   background-color: var(--MainBG);
+
+  z-index: ${Z_INDEX.Navigation};
 
   @media (max-width: ${DeviceSize.pc}) {
     gap: 3rem;

--- a/components/common/Nav/NavContainer.tsx
+++ b/components/common/Nav/NavContainer.tsx
@@ -70,12 +70,24 @@ const Wrapper = styled.div`
 `;
 
 const Title = styled.div`
-  width: 20rem;
+  width: 30rem;
+
+  display: flex;
+  align-items: center;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    font-size: 1.8rem;
+  }
+`;
+
+const TitleText = styled.span`
+  width: 25rem;
+
+  display: block;
 
   color: var(--Black33);
   font-size: 2rem;
   font-weight: 700;
-
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -87,21 +99,6 @@ const Title = styled.div`
 
   &::-webkit-scrollbar {
     display: none;
-  }
-
-  @media (max-width: ${DeviceSize.mobile}) {
-    font-size: 1.8rem;
-  }
-`;
-
-const TitleText = styled.span`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-
-  &:hover {
-    text-overflow: clip;
-    overflow: auto;
   }
 
   @media (max-width: ${DeviceSize.mobile}) {

--- a/components/common/Nav/Profile.tsx
+++ b/components/common/Nav/Profile.tsx
@@ -134,6 +134,10 @@ const Name = styled.div`
     overflow: auto;
   }
 
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
   @media (max-width: ${DeviceSize.mobile}) {
     display: none;
   }

--- a/components/common/Nav/SettingNav.tsx
+++ b/components/common/Nav/SettingNav.tsx
@@ -1,6 +1,7 @@
 import LogoButton from "@/components/common/Buttons/LogoButton";
 import Profile from "@/components/common/Nav/Profile";
 import { DeviceSize } from "@/styles/DeviceSize";
+import { Z_INDEX } from "@/styles/ZindexStyles";
 import styled from "styled-components";
 
 const SettingNav = () => {
@@ -23,8 +24,15 @@ const SettingNav = () => {
 export default SettingNav;
 
 const Wrapper = styled.div`
+  height: 7rem;
+
   padding: 2.3rem 8rem 2.3rem 34rem;
   border-bottom: 1px solid var(--Grayd9);
+
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
 
   display: flex;
   flex-direction: row;
@@ -32,6 +40,8 @@ const Wrapper = styled.div`
   gap: 4rem;
 
   background-color: var(--MainBG);
+
+  z-index: ${Z_INDEX.Navigation};
 
   @media (max-width: ${DeviceSize.pc}) {
     gap: 3rem;

--- a/components/common/Nav/SettingNav.tsx
+++ b/components/common/Nav/SettingNav.tsx
@@ -52,6 +52,8 @@ const Wrapper = styled.div`
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
+    height: 6rem;
+
     padding: 1.3rem 1.2rem;
   }
 `;

--- a/components/common/SideMenu/SettingSideMenu.tsx
+++ b/components/common/SideMenu/SettingSideMenu.tsx
@@ -37,7 +37,7 @@ const Wrapper = styled.div`
 
   padding: 2rem 1.2rem;
 
-  position: absolute;
+  position: fixed;
   top: 0;
 
   display: flex;
@@ -60,11 +60,12 @@ const Wrapper = styled.div`
 
     padding: 0;
 
+    border-right: none;
     border-bottom: 1px solid var(--Grayd9);
 
     flex-direction: row;
 
-    top: 6.5rem;
+    top: 7rem;
   }
 `;
 
@@ -91,7 +92,7 @@ const ButtonContainer = styled.div`
 
   @media (max-width: ${DeviceSize.mobile}) {
     margin: 0;
-    padding-left: 6.6rem;
+    padding-left: 7.2rem;
 
     flex-direction: row;
     align-items: center;

--- a/components/common/SideMenu/SettingSideMenu.tsx
+++ b/components/common/SideMenu/SettingSideMenu.tsx
@@ -65,7 +65,9 @@ const Wrapper = styled.div`
 
     flex-direction: row;
 
-    top: 7rem;
+    top: 6rem;
+
+    z-index: 1;
   }
 `;
 

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -54,6 +54,7 @@ const SideMenu = () => {
   const [editDashboard, setEditDashboard] = useAtom(dashboardListAtom);
   const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const wrapperRef = useRef(null);
+  const [isHovered, setIsHovered] = useState(false); //스크롤바 커스텀
 
   const scrollContainerRef = useRef(null);
   const { startRef, endRef, handleScrollNavClick, isScrollingUp } = useInfiniteScrollNavigator(scrollContainerRef);
@@ -66,6 +67,14 @@ const SideMenu = () => {
 
   const togglePopup = () => {
     setIsPopupVisible((prev) => !prev);
+  };
+
+  const handleMouseEnter = () => {
+    setIsHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsHovered(false);
   };
 
   useEffect(() => {
@@ -205,18 +214,23 @@ const DashboardList = styled.div`
   width: 100%;
   height: 100%;
 
-  overflow: auto;
+  overflow-y: hidden;
 
   margin-top: 1.8rem;
 
   display: flex;
   flex-direction: column;
 
+  &:hover {
+    overflow-y: auto;
+  }
+
   @media (max-width: ${DeviceSize.tablet}) {
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
     width: 4rem;
+    max-height: 70rem;
 
     margin-top: 1.6rem;
   }
@@ -280,6 +294,15 @@ const DashboardTitle = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   position: relative;
+
+  &:hover {
+    text-overflow: clip;
+    overflow: auto;
+  }
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   @media (max-width: ${DeviceSize.tablet}) {
     width: 55%;

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -48,7 +48,7 @@ const Dashboard = ({ color, title, createdByMe, boardId }: DashboardProps) => {
 
 const SideMenu = () => {
   const [isPopupVisible, setIsPopupVisible] = useState(false);
-  const [cursorId, setCursorId] = useState<number | null>(null);
+  // const [cursorId, setCursorId] = useState<number | null>(null);
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
   const [invitations, setInvitations] = useAtom(invitationsAtom); // 초대 목록!!
   const [editDashboard, setEditDashboard] = useAtom(dashboardListAtom);
@@ -72,6 +72,7 @@ const SideMenu = () => {
     const loadDashboardList = async () => {
       const res = await getDashboardList({
         token: localStorage.getItem("accessToken"),
+        size: 500,
         navigationMethod: "infiniteScroll",
       });
       if (res && res.dashboards) {
@@ -102,7 +103,7 @@ const SideMenu = () => {
           </DashboardList>
         </Popup>
       )}
-      <HeaderWrapper>
+      <HeaderWrapper ref={startRef}>
         <Title>Dash Boards</Title>
         <StyledAddButton
           alt="추가 버튼"
@@ -118,7 +119,7 @@ const SideMenu = () => {
           return (
             <div key={dashboard.id}>
               <Dashboard color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} boardId={dashboard.id} />
-              {cursorId == dashboard.id && <div ref={targetRef}>얍뽕짠</div>}
+              {/* {cursorId == dashboard.id && <div ref={targetRef}>얍뽕짠</div>} */}
             </div>
           );
         })}
@@ -129,11 +130,11 @@ const SideMenu = () => {
         </ModalWrapper>
       )}
       <div ref={endRef} />
-      {PAGE_SIZE < dashboards.length && (
+      {/* {dashboards.length > 17 && (
         <ScrollNavigateButton onClick={() => handleScrollNavClick()}>
           <ScrollNavigateIcon $isScrollingUp={isScrollingUp} />
         </ScrollNavigateButton>
-      )}
+      )} */}
     </Wrapper>
   );
 };
@@ -148,7 +149,7 @@ const Wrapper = styled.div`
 
   border-right: 1px solid var(--Grayd9);
 
-  position: absolute;
+  position: fixed;
   top: 0;
 
   display: flex;
@@ -202,7 +203,7 @@ const StyledAddButton = styled(AddButton)`
 
 const DashboardList = styled.div`
   width: 100%;
-  height: 10rem;
+  height: 100%;
 
   overflow: auto;
 

--- a/pages/dashboard/[boardid]/edit.tsx
+++ b/pages/dashboard/[boardid]/edit.tsx
@@ -83,6 +83,10 @@ const Wrapper = styled.div`
   top: 7rem;
 
   background-color: var(--MainLight);
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    top: 6rem;
+  }
 `;
 
 const Container = styled.div`

--- a/pages/dashboard/[boardid]/edit.tsx
+++ b/pages/dashboard/[boardid]/edit.tsx
@@ -76,14 +76,19 @@ const DashboardEditPage = () => {
 export default DashboardEditPage;
 
 const Wrapper = styled.div`
-  height: 100vh;
+  height: 100%;
+  min-height: calc(100vh - 7rem);
+
+  position: relative;
+  top: 7rem;
 
   background-color: var(--MainLight);
 `;
 
 const Container = styled.div`
-  margin-top: 2rem;
-  margin-left: 32rem;
+  margin-left: 30rem;
+
+  padding: 2rem;
 
   display: flex;
   flex-direction: column;

--- a/pages/dashboard/[boardid]/index.tsx
+++ b/pages/dashboard/[boardid]/index.tsx
@@ -19,13 +19,18 @@ const DashBoardPage = () => {
 
       if (res !== null) {
         setDashboards(res);
-        const index = res.dashboards?.findIndex((v) => v.id == Number(boardid));
-
-        if (index === -1) {
-          router.push(`/404`);
-          return;
-        }
       }
+
+      // if (res !== null) {
+      //   const index = res.dashboards?.findIndex((v) => v.id == Number(boardid));
+
+      //   console.log(index);
+
+      //   if (index === -1) {
+      //     router.push(`/404`);
+      //     return;
+      //   }
+      // }
     };
     if (boardid) loadDashboardData();
   }, [boardid]);
@@ -47,15 +52,19 @@ const ColumnWrapper = styled.div`
   width: 100%;
   height: calc(100vh - 7rem);
 
-  overflow: scroll;
+  position: relative;
+  top: 7rem;
 
+  background-color: var(--Grayfa);
+
+  overflow: scroll;
   &::-webkit-scrollbar {
     display: none;
   }
 
-  background-color: var(--Grayfa);
-
   @media (max-width: ${DeviceSize.mobile}) {
+    top: 6rem;
+
     height: calc(100vh - 6rem);
   }
 `;

--- a/pages/mydashboard/index.tsx
+++ b/pages/mydashboard/index.tsx
@@ -44,7 +44,10 @@ const SideMenuWrapper = styled.div`
 
 const Container = styled.div`
   height: 100%;
-  min-height: 100vh;
+  min-height: calc(100vh - 7rem);
+
+  position: relative;
+  top: 7rem;
 
   display: flex;
   flex-direction: column;
@@ -60,6 +63,8 @@ const Container = styled.div`
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
+    top: 6rem;
+
     margin-left: 6.7rem;
   }
 `;

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -43,6 +43,8 @@ const Wrapper = styled.div`
   top: 7rem;
 
   @media (max-width: ${DeviceSize.mobile}) {
+    top: 6rem;
+
     height: calc(100vh - 12rem);
   }
 `;

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -35,14 +35,22 @@ const Mypage = () => {
 export default Mypage;
 
 const Wrapper = styled.div`
-  height: 145.3rem;
+  height: calc(100vh - 7rem);
 
   background-color: var(--MainLight);
+
+  position: relative;
+  top: 7rem;
+
+  @media (max-width: ${DeviceSize.mobile}) {
+    height: calc(100vh - 12rem);
+  }
 `;
 
 const Container = styled.div`
-  margin-top: 2rem;
-  margin-left: 32rem;
+  margin-left: 30rem;
+
+  padding: 2rem;
 
   display: flex;
   flex-direction: column;
@@ -54,6 +62,6 @@ const Container = styled.div`
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
-    margin: 7rem 1.2rem 0 1.2rem;
+    margin: 5rem 1.2rem 0 1.2rem;
   }
 `;

--- a/styles/GlobalStyles.ts
+++ b/styles/GlobalStyles.ts
@@ -25,6 +25,16 @@ const GlobalStyles = createGlobalStyle`
       padding: 0;
       border: 0;
       vertical-align: baseline;
+
+      &::-webkit-scrollbar {
+        width: 0.5rem;
+        height: 0.5rem;
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background-color: var(--ScrollBar);
+        border-radius: 5rem;
+      }
   }
 
   a {

--- a/styles/ZindexStyles.ts
+++ b/styles/ZindexStyles.ts
@@ -3,6 +3,8 @@
  * 컴포넌트이름+스타일컴포넌트이름
  */
 export const Z_INDEX = {
+  ModalWrapper: 9999,
+
   MemberListDropdown_Dropdown: 2000,
 
   TaskModal_StyledKebabModal: 1500,
@@ -16,8 +18,6 @@ export const Z_INDEX = {
   SideMenu_Popup: 999,
 
   Navigation: 900,
-
-  MyDashboardList_ModalBackdrop: 10,
 
   ProfileImages_NumberWrapper: 3,
 

--- a/styles/ZindexStyles.ts
+++ b/styles/ZindexStyles.ts
@@ -3,15 +3,23 @@
  * 컴포넌트이름+스타일컴포넌트이름
  */
 export const Z_INDEX = {
-  Profile_DropdownMenu: 1000,
-  ProfileImages_NumberWrapper: 3,
-  SettingSideMenu_Wrapper: 3,
-  SideMenu_Wrapper: 3,
-  SideMenu_Popup: 999,
-  Column_ButtonWrapper: 1,
-  MyDashboardList_ModalBackdrop: 10,
+  MemberListDropdown_Dropdown: 2000,
+
   TaskModal_StyledKebabModal: 1500,
   ContactDropdown_List: 1500,
   StateDropdown_List: 1500,
-  MemberListDropdown_Dropdown: 2000,
+
+  Profile_DropdownMenu: 1000,
+
+  SettingSideMenu_Wrapper: 999,
+  SideMenu_Wrapper: 999,
+  SideMenu_Popup: 999,
+
+  Navigation: 900,
+
+  MyDashboardList_ModalBackdrop: 10,
+
+  ProfileImages_NumberWrapper: 3,
+
+  Column_ButtonWrapper: 1,
 };


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- [x]  header, 사이드메뉴 모두 fixed로 위치고정
- [x]  대시보드 edit페이지의 height
- [x]  header의 위치를 fixed로 하면서 생기는 나머지 wrapper의 margin-top 수정,  (스크롤해보면서)z-index 체크
- [x]  계정관리 페이지에 있는 돌아가기 버튼 width: 8rem
- [x]  대시보드 edit 페이지 대시보드 삭제하기 버튼이 아래로 넘치는 문제
- [x]  스크롤 디자인 통일
- [x]  모바일 사이즈일 때 사이드메뉴 팝업 길이 정해주기
- [x]  프로필 수정 mobile일 때 꾸겨짐
- [x]  scrollbar none: 사이드메뉴, mydashboardlist, 프로필 이름, 초대받은 대시보드, 나의 대시보드 수정, 멤버리스트 드롭다운
- [x]  태그 넘칠 때 스크롤 하기
- [x]  모바일일 때 멤버 리스트 드롭다운 위치 이상함..
- [x]  초대받은 대시보드 table 이름 - 초대자 텍스트 겹치는 문제 수정
- [x]  사이드바- 대시보드 이름 길게길게길게했을때 디자인 통일?
- [x] 절대 경로로 수정
***

## 📷 ScreenShot
---

## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
