### PR TITLE
🍀 refactor: 사이드메뉴, 댓글인풋 enter

### DIFF
--- a/components/Modal/AddTaskModal.tsx
+++ b/components/Modal/AddTaskModal.tsx
@@ -85,7 +85,7 @@ const AddTaskModal = ({ closeModalFunc, columnId }: AddTaskModalProps) => {
       <ModalInput $inputType="제목" label="제목" value={title} onChange={handleTitleChange} />
       <ModalInput $inputType="설명" label="설명" value={description} onChange={handleDescriptionChange} />
       <ModalInput $inputType="마감일" label="마감일" value={dueDate} />
-      <TagInput isModify={true} />
+      <TagInput />
       <ImageUploadInput type="modal" atomtype="cardImage" />
       <ButtonWrapper>
         <ButtonSet

--- a/components/Modal/EditTaskModal.tsx
+++ b/components/Modal/EditTaskModal.tsx
@@ -115,7 +115,7 @@ const EditTaskModal = ({ card, onCancel, onEdit }: EditTaskModalProps) => {
       <ModalInput label="제목" $inputType="제목" value={cardData.title} onChange={handleTitleChange} />
       <ModalInput $inputType="설명" label="설명" value={cardData.description} onChange={handleDescriptionChange} />
       <ModalInput label="마감일" $inputType="마감일" value={cardData.dueDate} />
-      <TagInput isModify={true} />
+      <TagInput />
       <ImageUploadInput atomtype="cardImage" type="modal" initialImageUrl={cardData.imageUrl} handleDeleteClick={setIsImageDeleteClick} />
       <ButtonWrapper>
         <ButtonSet

--- a/components/Modal/ModalInput/TagInput.tsx
+++ b/components/Modal/ModalInput/TagInput.tsx
@@ -8,10 +8,9 @@ import styled from "styled-components";
 interface TagsProps {
   handleOnClick: (targetValue: string) => void;
   tagValue: string[];
-  isModifyMode?: boolean;
 }
 
-const Tags = ({ handleOnClick, tagValue, isModifyMode }: TagsProps) => {
+const Tags = ({ handleOnClick, tagValue }: TagsProps) => {
   const scrollRef = useRef<HTMLDivElement>(null); //태그가 추가되어 스크롤이 생기면 오른쪽으로 스크롤이 이동하여 항상 최근태그를 보도록함
 
   useEffect(() => {
@@ -25,7 +24,7 @@ const Tags = ({ handleOnClick, tagValue, isModifyMode }: TagsProps) => {
       {tagValue.map((tag) => {
         return (
           <div key={tag} style={{ cursor: "pointer" }}>
-            <Tag tag={tag} handleOnClick={handleOnClick} isModifyMode={isModifyMode} />
+            <Tag tag={tag} handleOnClick={handleOnClick} />
           </div>
         );
       })}
@@ -33,7 +32,7 @@ const Tags = ({ handleOnClick, tagValue, isModifyMode }: TagsProps) => {
   );
 };
 
-const TagInput = ({ isModify = false }: { isModify?: boolean }) => {
+const TagInput = () => {
   const [inputValue, setInputValue] = useState("");
   const [tagValue, setTagValue] = useAtom(tagAtom);
   const [isTagModify, setIsTagModify] = useAtom(isTagModifyAtom);
@@ -75,7 +74,7 @@ const TagInput = ({ isModify = false }: { isModify?: boolean }) => {
     <InputBox>
       <Label>태그</Label>
       <InputArea ref={containerRef} onClick={() => setIsTagModify(true)}>
-        {tagValue && <Tags handleOnClick={handleDeleteTag} tagValue={tagValue} isModifyMode={isModify} />}
+        {tagValue && <Tags handleOnClick={handleDeleteTag} tagValue={tagValue} />}
         <StyledInput type="text" value={inputValue} onChange={handleInputChange} placeholder={tagValue.length == 0 ? "입력 후 Enter" : ""} onKeyDown={handlePressEnter} />
       </InputArea>
     </InputBox>
@@ -147,7 +146,7 @@ const TagArea = styled.div`
 
   max-width: 100%;
   height: 3rem;
-  
+
   overflow-x: scroll;
   overflow-y: hidden;
 `;

--- a/components/Modal/TaskModal/Comments.tsx
+++ b/components/Modal/TaskModal/Comments.tsx
@@ -64,6 +64,8 @@ const Comments = ({ cardData }: { cardData: Card }) => {
   };
 
   const submitComment = async (comment: string) => {
+    comment = comment.replaceAll(/(\n|\r\n)/g, "<br>");
+    console.log(comment);
     const res = await postComments({
       token,
       content: comment,
@@ -72,6 +74,7 @@ const Comments = ({ cardData }: { cardData: Card }) => {
       dashboardId: Number(boardid),
     });
 
+    if (res) res.content = res?.content.replaceAll("<br>", "\n");
     if (res && commentsData.length == 0) setCommentsData([res].splice(0));
     if (res && commentsData.length > 0) setCommentsData([res, ...commentsData]);
     watchCommentCount();
@@ -230,7 +233,7 @@ const CommentItem = styled.div`
   }
 `;
 
-const CommentContent = styled.div`
+const CommentContent = styled.pre`
   margin: 0.6rem 0 1.2rem 0;
 
   display: flex;

--- a/components/MyDashboardList.tsx
+++ b/components/MyDashboardList.tsx
@@ -5,7 +5,7 @@ import ButtonSet from "@/components/common/Buttons/ButtonSet";
 import { DASHBOARD_COLOR } from "@/constants/ColorConstant";
 import { useModal } from "@/hooks/useModal";
 import { usePagination } from "@/hooks/usePagination";
-import { dashboardColorAtom, invitationsAtom } from "@/states/atoms";
+import { dashboardColorAtom, invitationsAtom, newDashboardAtom } from "@/states/atoms";
 import { DeviceSize } from "@/styles/DeviceSize";
 import { useAtom } from "jotai";
 import Link from "next/link";
@@ -32,6 +32,7 @@ const MyDashboardList = () => {
   const { currentPage, setCurrentPage, handlePageChange } = usePagination(totalPageCount);
   const [invitations] = useAtom(invitationsAtom);
   const [dashboardColor, setDashboardColor] = useAtom(dashboardColorAtom);
+  const [newDashboard, setNewDashboard] = useAtom(newDashboardAtom);
 
   const isTitleExist = (titleToCheck: string) => {
     return dashboards.some((v) => v.title === titleToCheck);
@@ -47,14 +48,15 @@ const MyDashboardList = () => {
 
   const handleAddModal = async (data: FormData) => {
     const res = await postDashboard({ token: localStorage.getItem("accessToken"), title: data.inputData, color: dashboardColor });
-    setDashboardColor(`${DASHBOARD_COLOR[0]}`);
+    setDashboardColor(`${DASHBOARD_COLOR[0]}`); //초기화
 
     if (res == null) {
       alert("대시보드 생성에 실패했습니다.");
       closeModalFunc();
       return;
     }
-    currentPage === 1 ? loadDashboardList() : setCurrentPage(1);
+
+    setNewDashboard(res);
 
     closeModalFunc();
   };
@@ -76,6 +78,10 @@ const MyDashboardList = () => {
   useEffect(() => {
     loadDashboardList();
   }, [currentPage, invitations]);
+
+  useEffect(() => {//사이드메뉴 바뀌면 대시보드리스트도 반영
+    currentPage === 1 ? loadDashboardList() : setCurrentPage(1);
+  }, [newDashboard]);
 
   return (
     <Wrapper>

--- a/components/common/Chip/Tag.tsx
+++ b/components/common/Chip/Tag.tsx
@@ -5,14 +5,14 @@ import { TiDelete } from "react-icons/ti";
 import { isTagModifyAtom } from "@/states/atoms";
 import { useAtom } from "jotai";
 
-const Tag = ({ tag, handleOnClick, isModifyMode }: { tag: string; handleOnClick: (targetTag: string) => void; isModifyMode?: boolean }) => {
+const Tag = ({ tag, handleOnClick }: { tag: string; handleOnClick?: (targetTag: string) => void }) => {
   const [isTagModify] = useAtom(isTagModifyAtom);
   const tagNum = tag?.charCodeAt(0) % 10;
 
   return (
     <Container $bgColor={TAG_COLOR[tagNum].bgColor} $textColor={TAG_COLOR[tagNum].textColor}>
       {tag}
-      {isTagModify && isModifyMode && (
+      {isTagModify && handleOnClick && (
         <div
           style={{ height: "1.6rem" }}
           onClick={() => {

--- a/components/common/Nav/NavContainer.tsx
+++ b/components/common/Nav/NavContainer.tsx
@@ -63,7 +63,7 @@ const Wrapper = styled.div`
   @media (max-width: ${DeviceSize.mobile}) {
     height: 6rem;
 
-    padding: 1.3rem 1rem 1.3rem 9.1rem;
+    padding: 1.3rem 1rem 1.3rem 8.1rem;
 
     gap: 1rem;
   }
@@ -76,7 +76,7 @@ const Title = styled.div`
   align-items: center;
 
   @media (max-width: ${DeviceSize.mobile}) {
-    font-size: 1.8rem;
+    min-width: 10rem;
   }
 `;
 
@@ -102,7 +102,8 @@ const TitleText = styled.span`
   }
 
   @media (max-width: ${DeviceSize.mobile}) {
-    display: none;
+    width: 80%;
+    font-size: 1.6rem;
   }
 `;
 
@@ -115,6 +116,9 @@ const Content = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+  @media (max-width: ${DeviceSize.mobile}) {
+    gap: 0.5rem;
+  }
 `;
 
 const Line = styled.div`

--- a/components/common/SideMenu/SideMenu.tsx
+++ b/components/common/SideMenu/SideMenu.tsx
@@ -1,25 +1,23 @@
-import AddButton from "@/assets/icons/add-box.svg";
-import Crown from "@/assets/icons/crown.svg";
-import LogoButton from "@/components/common/Buttons/LogoButton";
-import { DeviceSize } from "@/styles/DeviceSize";
-import styled from "styled-components";
-import ArrowButton from "@/assets/icons/arrow-forward.svg";
-import { useEffect, useState, useRef } from "react";
-import Link from "next/link";
-import { Z_INDEX } from "@/styles/ZindexStyles";
-import { getDashboardList } from "@/api/dashboards";
-import { useAtom } from "jotai";
-import { invitationsAtom } from "@/states/atoms";
+import { getDashboardList, postDashboard } from "@/api/dashboards";
 import { Dashboard } from "@/api/dashboards/dashboards.types";
-import { useModal } from "@/hooks/useModal";
-import ModalWrapper from "@/components/Modal/ModalWrapper";
+import AddButton from "@/assets/icons/add-box.svg";
+import ArrowButton from "@/assets/icons/arrow-forward.svg";
+import Crown from "@/assets/icons/crown.svg";
 import ModalContainer from "@/components/Modal/ModalContainer";
-import { useParams } from "next/navigation";
-import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
-import { useInfiniteScrollNavigator } from "@/hooks/useInfiniteScrollNavigator";
-import { FaArrowUpWideShort } from "react-icons/fa6";
+import ModalWrapper from "@/components/Modal/ModalWrapper";
+import LogoButton from "@/components/common/Buttons/LogoButton";
+import { DASHBOARD_COLOR } from "@/constants/ColorConstant";
+import { useModal } from "@/hooks/useModal";
+import { dashboardColorAtom, dashboardListAtom, invitationsAtom, newDashboardAtom } from "@/states/atoms";
+import { DeviceSize } from "@/styles/DeviceSize";
+import { Z_INDEX } from "@/styles/ZindexStyles";
+import { useAtom } from "jotai";
+import Link from "next/link";
 import { useRouter } from "next/router";
-import { dashboardListAtom } from "@/states/atoms";
+import { useEffect, useRef, useState } from "react";
+import { FaArrowUpWideShort } from "react-icons/fa6";
+import styled from "styled-components";
+import { FormData } from "@/components/Modal/ModalContainer";
 
 interface DashboardProps {
   boardId: number;
@@ -29,10 +27,7 @@ interface DashboardProps {
   closePopup?: () => void;
 }
 
-const PAGE_SIZE = 2;
-
 const Dashboard = ({ color, title, createdByMe, boardId }: DashboardProps) => {
-  // const param = useParams();
   const router = useRouter();
   const { boardid } = router.query;
   const isActive = boardId === Number(boardid);
@@ -48,16 +43,40 @@ const Dashboard = ({ color, title, createdByMe, boardId }: DashboardProps) => {
 
 const SideMenu = () => {
   const [isPopupVisible, setIsPopupVisible] = useState(false);
-  // const [cursorId, setCursorId] = useState<number | null>(null);
   const [dashboards, setDashboards] = useState<Dashboard[]>([]);
+  const [dashboardColor, setDashboardColor] = useAtom(dashboardColorAtom);
   const [invitations, setInvitations] = useAtom(invitationsAtom); // 초대 목록!!
   const [editDashboard, setEditDashboard] = useAtom(dashboardListAtom);
   const { isModalOpen, openModalFunc, closeModalFunc } = useModal();
   const wrapperRef = useRef(null);
-  const [isHovered, setIsHovered] = useState(false); //스크롤바 커스텀
+  const [newDashboard, setNewDashboard] = useAtom(newDashboardAtom);
 
-  const scrollContainerRef = useRef(null);
-  const { startRef, endRef, handleScrollNavClick, isScrollingUp } = useInfiniteScrollNavigator(scrollContainerRef);
+  const isTitleExist = (titleToCheck: string) => {
+    return dashboards.some((v) => v.title === titleToCheck);
+  };
+
+  const rules = {
+    required: "생성할 이름을 입력해주세요",
+    maxLength: { value: 15, message: "대시보드 이름은 15자를 초과할 수 없습니다." },
+    validate: (v: string) => {
+      if (isTitleExist(v)) return "이름이 중복되었습니다. 다시 입력해주세요!";
+    },
+  };
+
+  const handleAddModal = async (data: FormData) => {
+    const res = await postDashboard({ token: localStorage.getItem("accessToken"), title: data.inputData, color: dashboardColor });
+    setDashboardColor(`${DASHBOARD_COLOR[0]}`); //초기화
+
+    if (res == null) {
+      alert("대시보드 생성에 실패했습니다.");
+      closeModalFunc();
+      return;
+    }
+
+    setNewDashboard(res);
+
+    closeModalFunc();
+  };
 
   const handleClickOutside = (event: { target: string }) => {
     if (wrapperRef.current && !wrapperRef.current.contains(event.target)) {
@@ -67,14 +86,6 @@ const SideMenu = () => {
 
   const togglePopup = () => {
     setIsPopupVisible((prev) => !prev);
-  };
-
-  const handleMouseEnter = () => {
-    setIsHovered(true);
-  };
-
-  const handleMouseLeave = () => {
-    setIsHovered(false);
   };
 
   useEffect(() => {
@@ -90,6 +101,11 @@ const SideMenu = () => {
     };
     loadDashboardList();
   }, [editDashboard, invitations]);
+
+  useEffect(() => {
+    //대시보드리스트 바뀌면 사이드메뉴도 반영
+    if (newDashboard !== null) setDashboards((prev) => [newDashboard, ...prev]);
+  }, [newDashboard]);
 
   useEffect(() => {
     document.addEventListener("mousedown", handleClickOutside);
@@ -112,7 +128,7 @@ const SideMenu = () => {
           </DashboardList>
         </Popup>
       )}
-      <HeaderWrapper ref={startRef}>
+      <HeaderWrapper>
         <Title>Dash Boards</Title>
         <StyledAddButton
           alt="추가 버튼"
@@ -128,22 +144,15 @@ const SideMenu = () => {
           return (
             <div key={dashboard.id}>
               <Dashboard color={dashboard.color} title={dashboard.title} createdByMe={dashboard.createdByMe} boardId={dashboard.id} />
-              {/* {cursorId == dashboard.id && <div ref={targetRef}>얍뽕짠</div>} */}
             </div>
           );
         })}
       </DashboardList>
       {isModalOpen && (
         <ModalWrapper>
-          <ModalContainer title="새로운 대시보드" label="대시보드 이름" buttonType="생성" onClose={closeModalFunc} />
+          <ModalContainer title="새로운 대시보드" label="대시보드 이름" buttonType="생성" onClose={closeModalFunc} rules={rules} onSubmit={handleAddModal} />
         </ModalWrapper>
       )}
-      <div ref={endRef} />
-      {/* {dashboards.length > 17 && (
-        <ScrollNavigateButton onClick={() => handleScrollNavClick()}>
-          <ScrollNavigateIcon $isScrollingUp={isScrollingUp} />
-        </ScrollNavigateButton>
-      )} */}
     </Wrapper>
   );
 };
@@ -292,6 +301,7 @@ const DashboardTitle = styled.div`
   font-size: 1.8rem;
   font-weight: 500;
   overflow: hidden;
+  white-space: nowrap;
   text-overflow: ellipsis;
   position: relative;
 
@@ -380,6 +390,13 @@ const Popup = styled.div<{ $isPopupVisible: boolean }>`
     ${DashboardTitle} {
       display: block;
 
+      width: 9rem;
+
+      overflow: auto;
+      white-space: nowrap;
+      &::-webkit-scrollbar {
+        display: none;
+      }
       margin-right: 0.6rem;
     }
 

--- a/constants/ColorConstant.ts
+++ b/constants/ColorConstant.ts
@@ -13,4 +13,4 @@ export const TAG_COLOR = [
 
 export const PROFILE_COLOR = ["#A3C4A2", "#FDD446", "#76A5EA", "#0e465d", "#C4B1A2", "#ef823e", "#df8ec1", "#ea3835", "#701cb0", "#137549"];
 
-export const DASHBOARD_COLOR = ["#7ac555", "#760dde", "#ffa500", " #76a5ea", "#e876ea"];
+export const DASHBOARD_COLOR = ["#7ac555", "#760dde", "#ffa500", "#76a5ea", "#e876ea"];

--- a/states/atoms.tsx
+++ b/states/atoms.tsx
@@ -68,3 +68,5 @@ export const userProfileImageUrlAtom = atom<string>("");
 export const userDataAtom = atom<UserData | null>(null);
 
 export const isTagModifyAtom = atom<boolean>(false);
+
+export const newDashboardAtom = atom<Dashboard | null>(null); //사아드메뉴, 대시보드리스트 연동


### PR DESCRIPTION
## 🥺 Issue Number
---
## 📝 Description
- [x] 댓글 enter 줄바꿈 가능하게 했어요
- [x] 사이드메뉴, 대시보드리스트 추가 반영
- [x] 사이드메뉴 긴 이름 ...처리
- [x] 태그 불필요한 코드 삭제
- [x] 헤더 모바일 사이즈일 때 제목 5글자까지는 보이게 수정
***

## 📷 ScreenShot
---

https://github.com/SWCF-8TEAM/taskify/assets/144668146/e4b679cb-2df4-48c6-b9cb-16d62d704cd4




<img width="367" alt="스크린샷 2024-01-04 오후 7 15 36" src="https://github.com/SWCF-8TEAM/taskify/assets/144668146/0215443b-ccc8-49a3-bf27-85cbbec23e47">

![Uploading 스크린샷 2024-01-04 오후 7.38.20.png…]()


## ✅ PR CheckList
- [x] 커밋 메세지 컨벤션을 지켰습니다. <a href=https://velog.io/@dkdlel102/Git-커밋-메시지-컨벤션>커밋 컨벤션 참고</a>
